### PR TITLE
Fix error message when pressed Run while disconnected

### DIFF
--- a/nicos/clients/gui/panels/editor.py
+++ b/nicos/clients/gui/panels/editor.py
@@ -524,6 +524,9 @@ class EditorPanel(Panel):
     @pyqtSlot()
     def on_actionRun_triggered(self):
         script = self.validateScript()
+        if not self.client.isconnected:
+            self.client.signal('error', 'You are not connected to a server.')
+            return
         if script is None:
             return
         if not self.checkDirty(self.currentEditor, askonly=True):


### PR DESCRIPTION
This PR fixes the error message that pops up when one presses the `Run` button in `Script Editor` if there is no active connection to the server.