### PR TITLE
Fix nonetype error when no device is selected

### DIFF
--- a/nicos_ess/loki/gui/sampleconf.py
+++ b/nicos_ess/loki/gui/sampleconf.py
@@ -177,7 +177,8 @@ class ConfigEditDialog(QDialog):
         dlg.devBox.addItems(devlist)
         if not dlg.exec_():
             return
-        self._addRow(dlg.devBox.currentText(), str(dlg.widget.getValue()))
+        if dlg.widget is not None:
+            self._addRow(dlg.devBox.currentText(), str(dlg.widget.getValue()))
 
     def on_delDevBtn_clicked(self):
         srow = self.frm.posTbl.currentRow()


### PR DESCRIPTION
This PR fixes the `NoneType` error when no device is selected. The error occurs due to the initialisation `dlg.widget = None` at line `165`. When no device is selected, the call to `.getValue()` method at line `181` fails as `NoneType` has no such attribute.