### PR TITLE
Refactor save&apply buttons in Loki GUI

### DIFF
--- a/nicos_ess/loki/gui/sampleconf.py
+++ b/nicos_ess/loki/gui/sampleconf.py
@@ -279,7 +279,6 @@ class LokiSamplePanel(Panel):
     @pyqtSlot()
     def on_actionEmpty_triggered(self):
         self.sampleGroup.setEnabled(True)
-        self.dirty = True
 
     @pyqtSlot()
     def on_actionGenerate_triggered(self):
@@ -389,6 +388,7 @@ class LokiSamplePanel(Panel):
             self.on_list_itemClicked(newitem)
 
         self.sampleGroup.setEnabled(True)
+        self.dirty = True
 
     @pyqtSlot()
     def on_openFileBtn_clicked(self):
@@ -435,10 +435,10 @@ class LokiSamplePanel(Panel):
             if not fn.endswith('.py'):
                 fn += '.py'
             self.filename = fn
-        try:
-            self._save_script(self.filename, self._generate_script())
-        except Exception as err:
-            self.showError('Could not write file: %s' % err)
+            try:
+                self._save_script(self.filename, self._generate_script())
+            except Exception as err:
+                self.showError('Could not write file: %s' % err)
 
     def on_applyButton_rejected(self):
         self.closeWindow()

--- a/nicos_ess/loki/gui/sampleconf.py
+++ b/nicos_ess/loki/gui/sampleconf.py
@@ -278,7 +278,6 @@ class LokiSamplePanel(Panel):
 
     @pyqtSlot()
     def on_actionEmpty_triggered(self):
-        self._handle_btn_grp()
         self.sampleGroup.setEnabled(True)
         self.dirty = True
 
@@ -370,7 +369,6 @@ class LokiSamplePanel(Panel):
         self.list.setCurrentItem(firstitem)
         self.on_list_itemClicked(firstitem)
 
-        self._handle_btn_grp()
         self.sampleGroup.setEnabled(True)
         self.dirty = True
 
@@ -390,7 +388,6 @@ class LokiSamplePanel(Panel):
             self.list.setCurrentItem(newitem)
             self.on_list_itemClicked(newitem)
 
-        self._handle_btn_grp()
         self.sampleGroup.setEnabled(True)
 
     @pyqtSlot()
@@ -406,7 +403,6 @@ class LokiSamplePanel(Panel):
             self.showError('Could not read file: %s\n\n'
                            'Are you sure this is a sample file?' % err)
         else:
-            self._handle_btn_grp()
             self.sampleGroup.setEnabled(True)
             newitem = None
             for config in self.configs:
@@ -423,7 +419,7 @@ class LokiSamplePanel(Panel):
             return
         do_apply = role == QDialogButtonBox.ApplyRole
         if self.dirty and do_apply:
-            script = self._generate()
+            script = self._generate_script()
             self.client.run(script)
             self.showInfo('Sample info has been transferred to the daemon.')
         self.closeWindow()
@@ -440,7 +436,7 @@ class LokiSamplePanel(Panel):
                 fn += '.py'
             self.filename = fn
         try:
-            self._generate(self.filename, save=True)
+            self._save_script(self.filename, self._generate_script())
         except Exception as err:
             self.showError('Could not write file: %s' % err)
 
@@ -575,7 +571,7 @@ class LokiSamplePanel(Panel):
         for config in self.configs:
             config[key] = template
 
-    def _generate(self, filename=None, save=False):
+    def _generate_script(self):
         script = ['# LoKI sample file for NICOS\n',
                   '# Written: %s\n\n' % time.asctime(),
                   'ClearSamples()\n']
@@ -586,19 +582,12 @@ class LokiSamplePanel(Panel):
                 script.append(', ')
             del script[-1]  # remove last comma
             script.append(')\n')
-        if filename is not None and save:
-            with open(filename, 'w') as fp:
-                fp.writelines(script)
         return ''.join(script)
 
-    def _handle_btn_grp(self):
-        """
-        An auxiliary function to prevent code repetition while handling the
-        individual elements of `fileGroup`.
-        """
-        for button in [self.createBtn, self.retrieveBtn, self.openFileBtn]:
-            button.setEnabled(False)
-        self.saveButton.setEnabled(True)
+    @staticmethod
+    def _save_script(filename, script):
+        with open(filename, 'w') as fp:
+            fp.writelines(script)
 
 
 class MockSample(object):

--- a/nicos_ess/loki/gui/sampleconf.py
+++ b/nicos_ess/loki/gui/sampleconf.py
@@ -421,8 +421,8 @@ class LokiSamplePanel(Panel):
         if self.dirty:
             initialdir = self.client.eval('session.experiment.scriptpath', '')
             fn = QFileDialog.getSaveFileName(self, 'Save sample file',
-                                             initialdir, 'Sample files (*.py)')[
-                0]
+                                             initialdir,
+                                             'Sample files (*.py)')[0]
             if not fn:
                 return False
             if not fn.endswith('.py'):

--- a/nicos_ess/loki/gui/sampleconf.py
+++ b/nicos_ess/loki/gui/sampleconf.py
@@ -267,7 +267,7 @@ class LokiSamplePanel(Panel):
 
     @pyqtSlot()
     def on_actionEmpty_triggered(self):
-        self.fileGroup.setEnabled(False)
+        self.handle_btn_grp()
         self.sampleGroup.setEnabled(True)
         self.dirty = True
 
@@ -359,7 +359,7 @@ class LokiSamplePanel(Panel):
         self.list.setCurrentItem(firstitem)
         self.on_list_itemClicked(firstitem)
 
-        self.fileGroup.setEnabled(False)
+        self.handle_btn_grp()
         self.sampleGroup.setEnabled(True)
         self.dirty = True
 
@@ -379,7 +379,7 @@ class LokiSamplePanel(Panel):
             self.list.setCurrentItem(newitem)
             self.on_list_itemClicked(newitem)
 
-        self.fileGroup.setEnabled(False)
+        self.handle_btn_grp()
         self.sampleGroup.setEnabled(True)
 
     @pyqtSlot()
@@ -395,7 +395,7 @@ class LokiSamplePanel(Panel):
             self.showError('Could not read file: %s\n\n'
                            'Are you sure this is a sample file?' % err)
         else:
-            self.fileGroup.setEnabled(False)
+            self.handle_btn_grp()
             self.sampleGroup.setEnabled(True)
             newitem = None
             for config in self.configs:
@@ -577,6 +577,15 @@ class LokiSamplePanel(Panel):
             with open(filename, 'w') as fp:
                 fp.writelines(script)
         return ''.join(script)
+
+    def handle_btn_grp(self):
+        """
+        An auxiliary function to prevent code repetition while handling the
+        individual elements of `fileGroup`.
+        """
+        for button in [self.createBtn, self.retrieveBtn, self.openFileBtn]:
+            button.setEnabled(False)
+        self.saveButton.setEnabled(True)
 
 
 class MockSample(object):

--- a/nicos_ess/loki/gui/sampleconf.ui
+++ b/nicos_ess/loki/gui/sampleconf.ui
@@ -246,7 +246,7 @@
     </widget>
    </item>
    <item>
-    <widget class="QDialogButtonBox" name="buttonBox">
+    <widget class="QDialogButtonBox" name="applyButton">
      <property name="layoutDirection">
       <enum>Qt::RightToLeft</enum>
      </property>

--- a/nicos_ess/loki/gui/sampleconf.ui
+++ b/nicos_ess/loki/gui/sampleconf.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>693</width>
-    <height>559</height>
+    <width>771</width>
+    <height>580</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -142,6 +142,16 @@
         </property>
        </spacer>
       </item>
+      <item>
+       <widget class="QDialogButtonBox" name="saveButton">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="standardButtons">
+         <set>QDialogButtonBox::Save</set>
+        </property>
+       </widget>
+      </item>
      </layout>
      <zorder>openFileBtn</zorder>
      <zorder>createBtn</zorder>
@@ -151,6 +161,7 @@
      <zorder>retrieveBtn</zorder>
      <zorder>horizontalSpacer</zorder>
      <zorder>horizontalSpacer_5</zorder>
+     <zorder>saveButton</zorder>
     </widget>
    </item>
    <item>
@@ -236,11 +247,14 @@
    </item>
    <item>
     <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="layoutDirection">
+      <enum>Qt::RightToLeft</enum>
+     </property>
      <property name="orientation">
       <enum>Qt::Horizontal</enum>
      </property>
      <property name="standardButtons">
-      <set>QDialogButtonBox::Apply|QDialogButtonBox::Cancel|QDialogButtonBox::Save</set>
+      <set>QDialogButtonBox::Apply</set>
      </property>
     </widget>
    </item>

--- a/nicos_ess/loki/gui/sampleconf_one.ui
+++ b/nicos_ess/loki/gui/sampleconf_one.ui
@@ -283,7 +283,7 @@
         </font>
        </property>
        <property name="text">
-        <string>Edit sample configurationm</string>
+        <string>Edit sample configuration</string>
        </property>
       </widget>
      </item>


### PR DESCRIPTION
This PR refactors the corresponding codes for `save` and `apply` buttons in the Loki GUI. With these changes `save` button only does save the script, while `apply` button sends the script to the `daemon` without saving it.