### PR TITLE
Renamed sample related buttons

### DIFF
--- a/nicos_ess/loki/gui/sampleconf.py
+++ b/nicos_ess/loki/gui/sampleconf.py
@@ -413,32 +413,29 @@ class LokiSamplePanel(Panel):
             self.on_list_itemClicked(newitem)
             self.filename = fn
 
-    def on_applyButton_clicked(self, button):
-        role = self.applyButton.buttonRole(button)
-        if role == QDialogButtonBox.RejectRole:
-            return
-        do_apply = role == QDialogButtonBox.ApplyRole
-        if self.dirty and do_apply:
+    @pyqtSlot()
+    def on_applyBtn_clicked(self):
+        if self.dirty:
             script = self._generate_script()
             self.client.run(script)
             self.showInfo('Sample info has been transferred to the daemon.')
         self.closeWindow()
 
-    def on_saveButton_clicked(self):
-        if self.dirty:
-            initialdir = self.client.eval('session.experiment.scriptpath', '')
-            fn = QFileDialog.getSaveFileName(self, 'Save sample file',
-                                             initialdir,
-                                             'Sample files (*.py)')[0]
-            if not fn:
-                return False
-            if not fn.endswith('.py'):
-                fn += '.py'
-            self.filename = fn
-            try:
-                self._save_script(self.filename, self._generate_script())
-            except Exception as err:
-                self.showError('Could not write file: %s' % err)
+    @pyqtSlot()
+    def on_saveBtn_clicked(self):
+        initialdir = self.client.eval('session.experiment.scriptpath', '')
+        fn = QFileDialog.getSaveFileName(self, 'Save sample file',
+                                         initialdir,
+                                         'Sample files (*.py)')[0]
+        if not fn:
+            return False
+        if not fn.endswith('.py'):
+            fn += '.py'
+        self.filename = fn
+        try:
+            self._save_script(self.filename, self._generate_script())
+        except Exception as err:
+            self.showError('Could not write file: %s' % err)
 
     def on_applyButton_rejected(self):
         self.closeWindow()

--- a/nicos_ess/loki/gui/sampleconf.py
+++ b/nicos_ess/loki/gui/sampleconf.py
@@ -388,7 +388,7 @@ class LokiSamplePanel(Panel):
             self.on_list_itemClicked(newitem)
 
         self.sampleGroup.setEnabled(True)
-        self.dirty = True
+        self.dirty = False
 
     @pyqtSlot()
     def on_openFileBtn_clicked(self):
@@ -419,7 +419,7 @@ class LokiSamplePanel(Panel):
             script = self._generate_script()
             self.client.run(script)
             self.showInfo('Sample info has been transferred to the daemon.')
-        self.closeWindow()
+        self.dirty = False
 
     @pyqtSlot()
     def on_saveBtn_clicked(self):

--- a/nicos_ess/loki/gui/sampleconf.py
+++ b/nicos_ess/loki/gui/sampleconf.py
@@ -437,9 +437,6 @@ class LokiSamplePanel(Panel):
         except Exception as err:
             self.showError('Could not write file: %s' % err)
 
-    def on_applyButton_rejected(self):
-        self.closeWindow()
-
     def _clearDisplay(self):
         item = self.frame.layout().takeAt(0)
         if item:

--- a/nicos_ess/loki/gui/sampleconf.py
+++ b/nicos_ess/loki/gui/sampleconf.py
@@ -379,13 +379,15 @@ class LokiSamplePanel(Panel):
         # convert readonlydict to normal dict
         for config in self.configs:
             config['position'] = dict(config['position'].items())
-        newitem = None
+        # Clear the current contents
+        self.list.clear()
+        last_item = None
         for config in self.configs:
-            newitem = QListWidgetItem(config['name'], self.list)
+            last_item = QListWidgetItem(config['name'], self.list)
         # select the last item
-        if newitem:
-            self.list.setCurrentItem(newitem)
-            self.on_list_itemClicked(newitem)
+        if last_item:
+            self.list.setCurrentItem(last_item)
+            self.on_list_itemClicked(last_item)
 
         self.sampleGroup.setEnabled(True)
         self.dirty = False

--- a/nicos_ess/loki/gui/sampleconf.ui
+++ b/nicos_ess/loki/gui/sampleconf.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>771</width>
+    <width>933</width>
     <height>580</height>
    </rect>
   </property>
@@ -33,11 +33,11 @@
          <enum>Qt::Horizontal</enum>
         </property>
         <property name="sizeType">
-         <enum>QSizePolicy::Expanding</enum>
+         <enum>QSizePolicy::Minimum</enum>
         </property>
         <property name="sizeHint" stdset="0">
          <size>
-          <width>60</width>
+          <width>10</width>
           <height>20</height>
          </size>
         </property>
@@ -118,7 +118,7 @@
          </size>
         </property>
         <property name="text">
-         <string>Load from file...</string>
+         <string>Import from file...</string>
         </property>
         <property name="icon">
          <iconset resource="../../../resources/nicos-gui.qrc">
@@ -132,23 +132,30 @@
          <enum>Qt::Horizontal</enum>
         </property>
         <property name="sizeType">
-         <enum>QSizePolicy::Fixed</enum>
+         <enum>QSizePolicy::Expanding</enum>
         </property>
         <property name="sizeHint" stdset="0">
          <size>
-          <width>20</width>
+          <width>10</width>
           <height>20</height>
          </size>
         </property>
        </spacer>
       </item>
       <item>
-       <widget class="QDialogButtonBox" name="saveButton">
-        <property name="orientation">
-         <enum>Qt::Horizontal</enum>
+       <widget class="QPushButton" name="saveButton">
+        <property name="minimumSize">
+         <size>
+          <width>140</width>
+          <height>30</height>
+         </size>
         </property>
-        <property name="standardButtons">
-         <set>QDialogButtonBox::Save</set>
+        <property name="text">
+         <string>Export to file...</string>
+        </property>
+        <property name="icon">
+         <iconset resource="../../../resources/nicos-gui.qrc">
+          <normaloff>:/save</normaloff>:/save</iconset>
         </property>
        </widget>
       </item>
@@ -245,16 +252,10 @@
      </layout>
     </widget>
    </item>
-   <item>
-    <widget class="QDialogButtonBox" name="applyButton">
-     <property name="layoutDirection">
-      <enum>Qt::RightToLeft</enum>
-     </property>
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-     <property name="standardButtons">
-      <set>QDialogButtonBox::Apply</set>
+   <item alignment="Qt::AlignRight">
+    <widget class="QPushButton" name="applyBtn">
+     <property name="text">
+      <string>Apply changes</string>
      </property>
     </widget>
    </item>


### PR DESCRIPTION
Renamed "save" and "apply" buttons as discussed. I think these names are more descriptive, we can see what the instrument scientist thinks next time we meet.
The "dirty" functionality was not behaving correctly so that has been changed.
Also there was a bug when the retrieve button was clicked twice - I fixed that. There are similar bugs for the other buttons, but I will fix those in a separate PR.