### PR TITLE
Fix broken sample buttons

### DIFF
--- a/nicos_ess/loki/gui/sampleconf.py
+++ b/nicos_ess/loki/gui/sampleconf.py
@@ -342,6 +342,8 @@ class LokiSamplePanel(Panel):
         if dlg.ax1RevBox.isChecked():
             dax1 = -dax1
 
+        self._clear_samples()
+
         n = 0
         for i in range(levels):
             for j in range(rows):
@@ -361,13 +363,14 @@ class LokiSamplePanel(Panel):
                     position=position,
                 )
                 self.configs.append(config)
-        firstitem = None
+
+        first_item = None
         for config in self.configs:
-            newitem = QListWidgetItem(config['name'], self.list)
-            firstitem = firstitem or newitem
+            new_item = QListWidgetItem(config['name'], self.list)
+            first_item = first_item or new_item
         # select the first item
-        self.list.setCurrentItem(firstitem)
-        self.on_list_itemClicked(firstitem)
+        self.list.setCurrentItem(first_item)
+        self.on_list_itemClicked(first_item)
 
         self.sampleGroup.setEnabled(True)
         self.dirty = True

--- a/nicos_ess/loki/gui/sampleconf.py
+++ b/nicos_ess/loki/gui/sampleconf.py
@@ -316,6 +316,11 @@ class LokiSamplePanel(Panel):
                         if revbox:
                             revbox.hide()
 
+        if not self.holder_info:
+            self.showError('Cannot auto-generate sample list as no sample '
+                           'changers are defined')
+            return
+
         dlg = dialogFromUi(self, findResource(
             'nicos_ess/loki/gui/sampleconf_gen.ui'))
         dlg.ax1Box.setValidator(DoubleValidator(self))

--- a/nicos_ess/loki/gui/sampleconf.py
+++ b/nicos_ess/loki/gui/sampleconf.py
@@ -426,9 +426,9 @@ class LokiSamplePanel(Panel):
 
     @pyqtSlot()
     def on_saveBtn_clicked(self):
-        initialdir = self.client.eval('session.experiment.scriptpath', '')
+        initial_dir = self.client.eval('session.experiment.scriptpath', '')
         filename = QFileDialog.getSaveFileName(self, 'Save sample file',
-                                         initialdir,
+                                         initial_dir,
                                          'Sample files (*.py)')[0]
         if not filename:
             return False

--- a/nicos_ess/loki/gui/sampleconf.py
+++ b/nicos_ess/loki/gui/sampleconf.py
@@ -278,6 +278,8 @@ class LokiSamplePanel(Panel):
 
     @pyqtSlot()
     def on_actionEmpty_triggered(self):
+        self.list.clear()
+        self._clearDisplay()
         self.sampleGroup.setEnabled(True)
 
     @pyqtSlot()
@@ -379,7 +381,6 @@ class LokiSamplePanel(Panel):
         # convert readonlydict to normal dict
         for config in self.configs:
             config['position'] = dict(config['position'].items())
-        # Clear the current contents
         self.list.clear()
         last_item = None
         for config in self.configs:

--- a/nicos_ess/loki/gui/sampleconf.py
+++ b/nicos_ess/loki/gui/sampleconf.py
@@ -272,7 +272,6 @@ class LokiSamplePanel(Panel):
 
         self.configs = []
         self.dirty = False
-        self.filename = None
         self.holder_info = options.get('holder_info', [])
         self.instrument = options.get('instrument', 'loki')
 
@@ -396,12 +395,12 @@ class LokiSamplePanel(Panel):
     @pyqtSlot()
     def on_openFileBtn_clicked(self):
         initialdir = self.client.eval('session.experiment.scriptpath', '')
-        fn = QFileDialog.getOpenFileName(self, 'Open sample file', initialdir,
+        filename = QFileDialog.getOpenFileName(self, 'Open sample file', initialdir,
                                          'Sample files (*.py)')[0]
-        if not fn:
+        if not filename:
             return
         try:
-            self.configs = parse_sampleconf(fn)
+            self.configs = parse_sampleconf(filename)
         except Exception as err:
             self.showError('Could not read file: %s\n\n'
                            'Are you sure this is a sample file?' % err)
@@ -415,7 +414,6 @@ class LokiSamplePanel(Panel):
             if newitem:
                 self.list.setCurrentItem(newitem)
             self.on_list_itemClicked(newitem)
-            self.filename = fn
             self.dirty = True
 
     @pyqtSlot()
@@ -429,16 +427,15 @@ class LokiSamplePanel(Panel):
     @pyqtSlot()
     def on_saveBtn_clicked(self):
         initialdir = self.client.eval('session.experiment.scriptpath', '')
-        fn = QFileDialog.getSaveFileName(self, 'Save sample file',
+        filename = QFileDialog.getSaveFileName(self, 'Save sample file',
                                          initialdir,
                                          'Sample files (*.py)')[0]
-        if not fn:
+        if not filename:
             return False
-        if not fn.endswith('.py'):
-            fn += '.py'
-        self.filename = fn
+        if not filename.endswith('.py'):
+            filename += '.py'
         try:
-            self._save_script(self.filename, self._generate_script())
+            self._save_script(filename, self._generate_script())
         except Exception as err:
             self.showError('Could not write file: %s' % err)
 

--- a/nicos_ess/loki/gui/sampleconf.py
+++ b/nicos_ess/loki/gui/sampleconf.py
@@ -277,7 +277,7 @@ class LokiSamplePanel(Panel):
 
     @pyqtSlot()
     def on_actionEmpty_triggered(self):
-        self.list.clear()
+        self._clear_samples()
         self._clearDisplay()
         self.sampleGroup.setEnabled(True)
 
@@ -371,6 +371,10 @@ class LokiSamplePanel(Panel):
 
         self.sampleGroup.setEnabled(True)
         self.dirty = True
+
+    def _clear_samples(self):
+        self.list.clear()
+        self.configs.clear()
 
     @pyqtSlot()
     def on_retrieveBtn_clicked(self):

--- a/nicos_ess/loki/gui/sampleconf.py
+++ b/nicos_ess/loki/gui/sampleconf.py
@@ -416,6 +416,7 @@ class LokiSamplePanel(Panel):
                 self.list.setCurrentItem(newitem)
             self.on_list_itemClicked(newitem)
             self.filename = fn
+            self.dirty = True
 
     @pyqtSlot()
     def on_applyBtn_clicked(self):

--- a/nicos_ess/loki/gui/sampleconf.py
+++ b/nicos_ess/loki/gui/sampleconf.py
@@ -406,6 +406,7 @@ class LokiSamplePanel(Panel):
             self.showError('Could not read file: %s\n\n'
                            'Are you sure this is a sample file?' % err)
         else:
+            self.list.clear()
             self.sampleGroup.setEnabled(True)
             newitem = None
             for config in self.configs:
@@ -613,7 +614,8 @@ def parse_sampleconf(filename):
           'ClearSamples': mocksample.reset,
           'SetSample': mocksample.define}
     with open(filename, 'r') as fp:
-        exec_(fp, ns)
+        for line in fp.readlines():
+            exec(line, ns)
     # The script needs to call this, if it doesn't it is not a sample file.
     if not mocksample.reset_called:
         raise ValueError('the script never calls ClearSamples()')

--- a/nicos_ess/loki/gui/sampleconf.py
+++ b/nicos_ess/loki/gui/sampleconf.py
@@ -334,7 +334,7 @@ class LokiSamplePanel(Panel):
             if row == nrows:
                 row = 0
                 col += 1
-        if not dlg.exec_():
+        if dlg.exec_() != QDialog.Accepted:
             return
         rows, levels, ax1, dax1, ax2, dax2 = dlg._info
         sax1 = float(dlg.ax1Box.text()) if ax1 else 0

--- a/nicos_ess/loki/gui/sampleconf.ui
+++ b/nicos_ess/loki/gui/sampleconf.ui
@@ -143,7 +143,7 @@
        </spacer>
       </item>
       <item>
-       <widget class="QPushButton" name="saveButton">
+       <widget class="QPushButton" name="saveBtn">
         <property name="minimumSize">
          <size>
           <width>140</width>
@@ -168,7 +168,7 @@
      <zorder>retrieveBtn</zorder>
      <zorder>horizontalSpacer</zorder>
      <zorder>horizontalSpacer_5</zorder>
-     <zorder>saveButton</zorder>
+     <zorder>saveBtn</zorder>
     </widget>
    </item>
    <item>

--- a/nicos_ess/loki/guiconfig.py
+++ b/nicos_ess/loki/guiconfig.py
@@ -12,7 +12,11 @@ main_window = docked(
         ),
         (
             "Samples",
-            vsplit(panel("nicos_ess.loki.gui.sampleconf.LokiSamplePanel")),  # vsplit
+            vsplit(panel("nicos_ess.loki.gui.sampleconf.LokiSamplePanel",
+            holder_info = [
+                ('Al 2-level',   (9,  2, 'sam_trans_x', 26.6,   'sam_trans_y', 105.05)),
+                ('Al 3-level',   (9,  3, 'sam_trans_x', 27,     'sam_trans_y', 75)),
+            ])),  # vsplit
         ),
         ("  ", panel("nicos_ess.gui.panels.empty.EmptyPanel")),
         (


### PR DESCRIPTION
I've gone through the code for the buttons and tried to find ways to break it, and if I managed to then I fixed it.

I added some place-holder sample changers so that for demos we can use the "generate" buttons - I also needed them for testing the code. At some point it would be good to tie it to the simulated LoKI sample changers, I'll create a ticket for that.