### PR TITLE
Move to using editing finished

### DIFF
--- a/nicos_ess/loki/gui/sampleconf.py
+++ b/nicos_ess/loki/gui/sampleconf.py
@@ -503,18 +503,16 @@ class LokiSamplePanel(Panel):
         layout = self.frame.layout()
         layout.addWidget(frm)
 
-        # Enable users the change the offset and aperture values at will
-        # without the need of opening any dialog window.
         frm.offsetBox.editingFinished.connect(lambda: self.set_offset(index,
-                                          frm.offsetBox.displayText()))
+                                              frm.offsetBox.displayText()))
         frm.apXBox.editingFinished.connect(lambda: self.set_aperture(index,
-                                       frm.apXBox.displayText(), 0))
+                                           frm.apXBox.displayText(), 0))
         frm.apYBox.editingFinished.connect(lambda: self.set_aperture(index,
-                                       frm.apYBox.displayText(), 1))
+                                           frm.apYBox.displayText(), 1))
         frm.apWBox.editingFinished.connect(lambda: self.set_aperture(index,
-                                       frm.apWBox.displayText(), 2))
+                                           frm.apWBox.displayText(), 2))
         frm.apHBox.editingFinished.connect(lambda: self.set_aperture(index,
-                                       frm.apHBox.displayText(), 3))
+                                           frm.apHBox.displayText(), 3))
 
         # Re-validate the values
         for box in [frm.offsetBox, frm.apXBox, frm.apYBox, frm.apWBox,

--- a/nicos_ess/loki/gui/sampleconf.py
+++ b/nicos_ess/loki/gui/sampleconf.py
@@ -471,15 +471,15 @@ class LokiSamplePanel(Panel):
 
         # Enable users the change the offset and aperture values at will
         # without the need of opening any dialog window.
-        frm.offsetBox.textChanged.connect(lambda: self.set_offset(index,
+        frm.offsetBox.editingFinished.connect(lambda: self.set_offset(index,
                                           frm.offsetBox.displayText()))
-        frm.apXBox.textChanged.connect(lambda: self.set_aperture(index,
+        frm.apXBox.editingFinished.connect(lambda: self.set_aperture(index,
                                        frm.apXBox.displayText(), 0))
-        frm.apYBox.textChanged.connect(lambda: self.set_aperture(index,
+        frm.apYBox.editingFinished.connect(lambda: self.set_aperture(index,
                                        frm.apYBox.displayText(), 1))
-        frm.apWBox.textChanged.connect(lambda: self.set_aperture(index,
+        frm.apWBox.editingFinished.connect(lambda: self.set_aperture(index,
                                        frm.apWBox.displayText(), 2))
-        frm.apHBox.textChanged.connect(lambda: self.set_aperture(index,
+        frm.apHBox.editingFinished.connect(lambda: self.set_aperture(index,
                                        frm.apHBox.displayText(), 3))
 
         # Re-validate the values

--- a/nicos_ess/loki/gui/sampleconf.py
+++ b/nicos_ess/loki/gui/sampleconf.py
@@ -457,6 +457,7 @@ class LokiSamplePanel(Panel):
         frm.addDevBtn.setVisible(False)
         frm.delDevBtn.setVisible(False)
         frm.readApBtn.setVisible(True)
+        frm.readApBtn.clicked.connect(self.on_readApBtn_clicked)
         frm.readDevsBtn.setVisible(False)
         frm.posTbl.setEnabled(False)
         relevant_list = [frm.offsetBox, frm.apXBox, frm.apYBox, frm.apWBox,
@@ -557,6 +558,9 @@ class LokiSamplePanel(Panel):
             self.on_list_itemClicked(self.list.item(self.list.currentRow()))
         else:
             self._clearDisplay()
+
+    def on_readApBtn_clicked(self):
+        QMessageBox.warning(self, 'Error', 'Not implemented yet!')
 
     def _copy_key(self, key):
         index = self.list.currentRow()

--- a/nicos_ess/loki/gui/sampleconf.py
+++ b/nicos_ess/loki/gui/sampleconf.py
@@ -290,8 +290,9 @@ class LokiSamplePanel(Panel):
 
     def toggle_controls_availability(self):
         for control in [
-            self.createBtn, self.retrieveBtn, self.openFileBtn, self.buttonBox,
-            self.newBtn, self.editBtn, self.delBtn, self.frame
+            self.createBtn, self.retrieveBtn, self.openFileBtn, self.applyBtn,
+            self.saveBtn, self.newBtn, self.editBtn, self.delBtn, self.frame,
+            self.list
         ]:
             control.setEnabled(self.client.isconnected)
 

--- a/nicos_ess/loki/gui/sampleconf.ui
+++ b/nicos_ess/loki/gui/sampleconf.ui
@@ -51,6 +51,9 @@
           <height>30</height>
          </size>
         </property>
+        <property name="focusPolicy">
+         <enum>Qt::StrongFocus</enum>
+        </property>
         <property name="text">
          <string>Create new</string>
         </property>
@@ -83,6 +86,9 @@
           <width>140</width>
           <height>30</height>
          </size>
+        </property>
+        <property name="focusPolicy">
+         <enum>Qt::StrongFocus</enum>
         </property>
         <property name="text">
          <string>Retrieve current</string>
@@ -117,6 +123,9 @@
           <height>30</height>
          </size>
         </property>
+        <property name="focusPolicy">
+         <enum>Qt::StrongFocus</enum>
+        </property>
         <property name="text">
          <string>Import from file...</string>
         </property>
@@ -149,6 +158,9 @@
           <width>140</width>
           <height>30</height>
          </size>
+        </property>
+        <property name="focusPolicy">
+         <enum>Qt::StrongFocus</enum>
         </property>
         <property name="text">
          <string>Export to file...</string>
@@ -215,6 +227,9 @@
        <layout class="QHBoxLayout" name="horizontalLayout_2">
         <item>
          <widget class="QPushButton" name="newBtn">
+          <property name="focusPolicy">
+           <enum>Qt::StrongFocus</enum>
+          </property>
           <property name="text">
            <string>New</string>
           </property>
@@ -222,6 +237,9 @@
         </item>
         <item>
          <widget class="QPushButton" name="editBtn">
+          <property name="focusPolicy">
+           <enum>Qt::StrongFocus</enum>
+          </property>
           <property name="text">
            <string>Edit</string>
           </property>
@@ -229,6 +247,9 @@
         </item>
         <item>
          <widget class="QPushButton" name="delBtn">
+          <property name="focusPolicy">
+           <enum>Qt::StrongFocus</enum>
+          </property>
           <property name="text">
            <string>Delete</string>
           </property>
@@ -254,6 +275,9 @@
    </item>
    <item alignment="Qt::AlignRight">
     <widget class="QPushButton" name="applyBtn">
+     <property name="focusPolicy">
+      <enum>Qt::StrongFocus</enum>
+     </property>
      <property name="text">
       <string>Apply changes</string>
      </property>

--- a/nicos_ess/loki/gui/sampleconf_summary.ui
+++ b/nicos_ess/loki/gui/sampleconf_summary.ui
@@ -152,6 +152,9 @@
        </item>
        <item row="0" column="6">
         <widget class="QPushButton" name="readApBtn">
+         <property name="focusPolicy">
+          <enum>Qt::StrongFocus</enum>
+         </property>
          <property name="text">
           <string>Read current</string>
          </property>


### PR DESCRIPTION
After some investigation, I worked out that we could change the buttons via Qt Designer to have a strong-focus; this means that when we click on the buttons the buttons take focus. This should mean that the editingFinished behviour for the text boxes should work properly now.

I also added a place-holder method for when the button for reading the aperture settings is clicked.