### PR TITLE
Check item is not None in on_list_itemClicked

### DIFF
--- a/nicos_ess/loki/gui/sampleconf.py
+++ b/nicos_ess/loki/gui/sampleconf.py
@@ -425,7 +425,6 @@ class LokiSamplePanel(Panel):
         # select the last item
         if last_item:
             self.list.setCurrentItem(last_item)
-            self.on_list_itemClicked(last_item)
 
         self.sampleGroup.setEnabled(True)
         self.dirty = False

--- a/nicos_ess/loki/gui/sampleconf.py
+++ b/nicos_ess/loki/gui/sampleconf.py
@@ -130,6 +130,10 @@ class ConfigEditDialog(QDialog):
         # Apply local customisations to the stylesheet
         self.setStyleSheet(ConfigEditDialog_QSS)
 
+        if not config:
+            self.frm.whatLbl.setText('New sample configuration')
+
+
     def maybeAccept(self):
         if not self.frm.nameBox.text():
             QMessageBox.warning(self, 'Error', 'Please enter a sample name.')
@@ -491,7 +495,7 @@ class LokiSamplePanel(Panel):
         frm = QFrame(self)
         loadUi(frm, findResource(
             'nicos_ess/loki/gui/ui_files/sampleconf_summary.ui'))
-        frm.whatLbl.setText('Sample configuration')
+        # frm.whatLbl.setText('Sample configuration')
         configToFrame(frm, self.configs[index])
         frm.addDevBtn.setVisible(False)
         frm.delDevBtn.setVisible(False)
@@ -559,7 +563,6 @@ class LokiSamplePanel(Panel):
             return
         self.dirty = True
         config = configFromFrame(dlg.frm)
-        dlg.frm.whatLbl.setText('New sample configuration')
         self.configs.append(config)
         new_item = QListWidgetItem(config['name'], self.list)
         self.list.setCurrentItem(new_item)

--- a/nicos_ess/loki/gui/sampleconf.py
+++ b/nicos_ess/loki/gui/sampleconf.py
@@ -497,7 +497,6 @@ class LokiSamplePanel(Panel):
         frm = QFrame(self)
         loadUi(frm, findResource(
             'nicos_ess/loki/gui/ui_files/sampleconf_summary.ui'))
-        # frm.whatLbl.setText('Sample configuration')
         configToFrame(frm, self.configs[index])
         frm.addDevBtn.setVisible(False)
         frm.delDevBtn.setVisible(False)

--- a/nicos_ess/loki/gui/sampleconf.py
+++ b/nicos_ess/loki/gui/sampleconf.py
@@ -563,7 +563,6 @@ class LokiSamplePanel(Panel):
         self.configs.append(config)
         new_item = QListWidgetItem(config['name'], self.list)
         self.list.setCurrentItem(new_item)
-        self.on_list_itemClicked(new_item)
 
     @pyqtSlot()
     def on_editBtn_clicked(self):

--- a/nicos_ess/loki/gui/sampleconf.py
+++ b/nicos_ess/loki/gui/sampleconf.py
@@ -491,6 +491,8 @@ class LokiSamplePanel(Panel):
 
     def on_list_itemClicked(self, item):
         self._clearDisplay()
+        if not item:
+            return
         index = self.list.row(item)
         frm = QFrame(self)
         loadUi(frm, findResource(

--- a/nicos_ess/loki/gui/ui_files/sampleconf_summary.ui
+++ b/nicos_ess/loki/gui/ui_files/sampleconf_summary.ui
@@ -301,7 +301,7 @@
         </font>
        </property>
        <property name="text">
-        <string>Edit sample configuration</string>
+        <string>Sample configuration</string>
        </property>
       </widget>
      </item>


### PR DESCRIPTION
Under very specific/rare conditions the item passed to on_list_itemClicked can be None. For example, if the sample list has items and the "Retrieve Current" button is pushed and tries to return an empty config.

I also refactored some minor labelling issues, nothing significant.