### PR TITLE
Remove Python 2 compatibility

### DIFF
--- a/nicos_ess/loki/gui/cmdlets.py
+++ b/nicos_ess/loki/gui/cmdlets.py
@@ -22,14 +22,11 @@
 #
 # *****************************************************************************
 
-"""Commandlets for KWS(-1)."""
-
-from __future__ import absolute_import, division, print_function
+"""Commandlets for LoKI."""
 
 from nicos.clients.gui.cmdlets import Cmdlet, register
 from nicos.guisupport.qt import QDialog, QIcon, QMessageBox, QSize, \
     QTableWidgetItem, QToolButton, pyqtSlot
-from nicos.pycompat import srepr
 from nicos.utils import findResource, formatDuration
 
 from nicos_ess.loki.gui.measdialogs import LOOPS, DetsetDialog, \
@@ -186,7 +183,7 @@ class MeasureTable(Cmdlet):
                     count_time = v.extra[1]
                 elif isinstance(v, Device):
                     devices_args.append(k)
-                    devices_args.append(srepr(v.getValue()))
+                    devices_args.append(repr(v.getValue()))
 
             items.append(f"\n##### Measurement {len(out) + 1}")
             if sample:

--- a/nicos_ess/loki/gui/instrconfig.py
+++ b/nicos_ess/loki/gui/instrconfig.py
@@ -87,7 +87,7 @@ class InstrumentConfigTool(DlgUtils, QMainWindow):
     def _update(self):
         try:
             configcode = self.client.eval(
-                '__import__("nicos_mlz").kws1._get_instr_config()')
+                '__import__("nicos_ess").loki._get_instr_config()')
             config = {'__builtins__': None}
             exec(configcode, config)
         except Exception:
@@ -120,7 +120,7 @@ class InstrumentConfigTool(DlgUtils, QMainWindow):
         code = TEMPLATE % info
         try:
             self.client.eval(
-                '__import__("nicos_mlz").kws1._apply_instr_config(%r)' % code)
+                '__import__("nicos_ess").loki._apply_instr_config(%r)' % code)
         except Exception:
             self.showError('Could not apply new config.')
             return

--- a/nicos_ess/loki/gui/instrconfig.py
+++ b/nicos_ess/loki/gui/instrconfig.py
@@ -22,13 +22,10 @@
 #
 # *****************************************************************************
 
-"""'Instrument reconfiguration' tool for KWS instruments."""
-
-from __future__ import absolute_import, division, print_function
+"""'Instrument reconfiguration' tool for LoKI"""
 
 from nicos.clients.gui.utils import DlgUtils, loadUi
 from nicos.guisupport.qt import QButtonGroup, QLabel, QMainWindow, QRadioButton
-from nicos.pycompat import exec_
 from nicos.utils import findResource
 
 TEMPLATE = '''\
@@ -92,7 +89,7 @@ class InstrumentConfigTool(DlgUtils, QMainWindow):
             configcode = self.client.eval(
                 '__import__("nicos_mlz").kws1._get_instr_config()')
             config = {'__builtins__': None}
-            exec_(configcode, config)
+            exec(configcode, config)
         except Exception:
             self.showError('Could not determine current config.')
             self.frame.setDisabled(True)

--- a/nicos_ess/loki/gui/protocol.py
+++ b/nicos_ess/loki/gui/protocol.py
@@ -24,14 +24,11 @@
 
 """Generate a measurement protocol from saved runs."""
 
-from __future__ import absolute_import, division, print_function
-
 from os import path
 
 from nicos.clients.gui.panels import Panel
 from nicos.clients.gui.utils import loadUi
 from nicos.guisupport.qt import QFileDialog, QPrintDialog, QPrinter, pyqtSlot
-from nicos.pycompat import to_utf8
 from nicos.utils import findResource
 
 
@@ -91,7 +88,7 @@ class ProtocolPanel(Panel):
         try:
             text = self.outText.toPlainText()
             with open(fn, 'wb') as fp:
-                fp.write(to_utf8(text))
+                fp.write(text)
         except Exception as err:
             self.showError('Could not save: %s' % err)
 

--- a/nicos_ess/loki/gui/sampleconf.py
+++ b/nicos_ess/loki/gui/sampleconf.py
@@ -25,8 +25,7 @@
 
 """LoKI sample configuration dialog."""
 
-from __future__ import absolute_import, division, print_function
-
+import builtins
 import math
 import time
 
@@ -37,7 +36,6 @@ from nicos.guisupport.qt import QDialog, QDialogButtonBox, QFileDialog, \
     QFrame, QLineEdit, QListWidgetItem, QMenu, QMessageBox, QRadioButton, \
     QTableWidgetItem, QVBoxLayout, pyqtSlot
 from nicos.guisupport.utils import DoubleValidator
-from nicos.pycompat import builtins, exec_, iteritems
 from nicos.utils import findResource
 
 
@@ -56,7 +54,7 @@ def configToFrame(frame, config):
     frame.apYBox.setText(str(config['aperture'][1]))
     frame.apWBox.setText(str(config['aperture'][2]))
     frame.apHBox.setText(str(config['aperture'][3]))
-    for i, (dev_name, position) in enumerate(iteritems(config['position'])):
+    for i, (dev_name, position) in enumerate(config['position'].items()):
         frame.posTbl.setItem(i, 0, QTableWidgetItem(dev_name))
         frame.posTbl.setItem(i, 1, QTableWidgetItem(str(position)))
     frame.posTbl.resizeRowsToContents()
@@ -629,7 +627,7 @@ class LokiSamplePanel(Panel):
             fp.writelines(script)
 
 
-class MockSample(object):
+class MockSample:
     def __init__(self):
         self.reset_called = False
         self.configs = []

--- a/nicos_ess/loki/gui/setup_panel.py
+++ b/nicos_ess/loki/gui/setup_panel.py
@@ -36,7 +36,6 @@ from nicos.guisupport.qt import QComboBox, QDialog, QDialogButtonBox, QFrame, \
     QHBoxLayout, QLabel, QListWidgetItem, QMessageBox, QPushButton, Qt, \
     pyqtSlot
 from nicos.guisupport.widget import NicosWidget
-from nicos.pycompat import iteritems, itervalues, listitems
 from nicos.utils import decodeAny, findResource
 
 
@@ -95,7 +94,7 @@ class ExpPanel(Panel):
             '__import__("nicos").commands.basic._listReceivers('
             '"nicos.devices.notifiers.Mailer")', {})
         emails = []
-        for data in itervalues(receiverinfo):
+        for data in receiverinfo.values():
             for (addr, what) in data:
                 if what == 'receiver' and addr not in emails:
                     emails.append(addr)
@@ -434,7 +433,7 @@ class SetupsPanel(Panel):
     def showSetupInfo(self, setup):
         info = self._setupinfo[str(setup)]
         devs = []
-        for devname, devconfig in iteritems(info['devices']):
+        for devname, devconfig in info['devices'].items():
             if not devconfig[1].get('lowlevel'):
                 devs.append(devname)
         devs = ', '.join(sorted(devs))
@@ -506,7 +505,7 @@ class SetupsPanel(Panel):
                     self, aliasname, selections,
                     preselect and self._prev_aliases.get(aliasname))
                 layout.addWidget(wid)
-        for name, wid in listitems(self._aliasWidgets):
+        for name, wid in list(self._aliasWidgets.items()):
             if name not in alias_config:
                 layout.takeAt(layout.indexOf(wid)).widget().deleteLater()
                 del self._aliasWidgets[name]


### PR DESCRIPTION
The GUI code still had some references to the compatibility layer for Python 2, this removes that.
Once this has been done we can re-sync this against the latest version of master.