### PR TITLE
Moving the UI files meant the path to the resources file was wrong

### DIFF
--- a/nicos_ess/loki/gui/ui_files/detsets.ui
+++ b/nicos_ess/loki/gui/ui_files/detsets.ui
@@ -29,7 +29,7 @@
          <string>Add new setting to the table</string>
         </property>
         <property name="icon">
-         <iconset resource="../../../resources/nicos-gui.qrc">
+         <iconset resource="../../../../resources/nicos-gui.qrc">
           <normaloff>:/add</normaloff>:/add</iconset>
         </property>
         <property name="iconSize">
@@ -51,7 +51,7 @@
         <string>Remove setting from the table</string>
        </property>
        <property name="icon">
-        <iconset resource="../../../resources/nicos-gui.qrc">
+        <iconset resource="../../../../resources/nicos-gui.qrc">
          <normaloff>:/remove</normaloff>:/remove</iconset>
        </property>
        <property name="iconSize">
@@ -84,7 +84,7 @@
         <string>Move setting up in the table</string>
        </property>
        <property name="icon">
-        <iconset resource="../../../resources/nicos-gui.qrc">
+        <iconset resource="../../../../resources/nicos-gui.qrc">
          <normaloff>:/up</normaloff>:/up</iconset>
        </property>
        <property name="iconSize">
@@ -101,7 +101,7 @@
         <string>Move setting down in the table</string>
        </property>
        <property name="icon">
-        <iconset resource="../../../resources/nicos-gui.qrc">
+        <iconset resource="../../../../resources/nicos-gui.qrc">
          <normaloff>:/down</normaloff>:/down</iconset>
        </property>
        <property name="iconSize">
@@ -131,7 +131,7 @@
         <string>Clear</string>
        </property>
        <property name="icon">
-        <iconset resource="../../../resources/nicos-gui.qrc">
+        <iconset resource="../../../../resources/nicos-gui.qrc">
          <normaloff>:/emergency</normaloff>:/emergency</iconset>
        </property>
        <property name="iconSize">
@@ -193,7 +193,7 @@
   <tabstop>buttonBox</tabstop>
  </tabstops>
  <resources>
-  <include location="../../../resources/nicos-gui.qrc"/>
+  <include location="../../../../resources/nicos-gui.qrc"/>
  </resources>
  <connections>
   <connection>

--- a/nicos_ess/loki/gui/ui_files/devices.ui
+++ b/nicos_ess/loki/gui/ui_files/devices.ui
@@ -50,7 +50,7 @@
           <string>Add a setpoint table for selected devices</string>
          </property>
          <property name="icon">
-          <iconset resource="../../../resources/nicos-gui.qrc">
+          <iconset resource="../../../../resources/nicos-gui.qrc">
            <normaloff>:/add</normaloff>:/add</iconset>
          </property>
          <property name="iconSize">
@@ -107,8 +107,8 @@
        <rect>
         <x>0</x>
         <y>0</y>
-        <width>582</width>
-        <height>416</height>
+        <width>570</width>
+        <height>385</height>
        </rect>
       </property>
      </widget>
@@ -130,7 +130,7 @@
   <tabstop>buttonBox</tabstop>
  </tabstops>
  <resources>
-  <include location="../../../resources/nicos-gui.qrc"/>
+  <include location="../../../../resources/nicos-gui.qrc"/>
  </resources>
  <connections>
   <connection>

--- a/nicos_ess/loki/gui/ui_files/devices_one.ui
+++ b/nicos_ess/loki/gui/ui_files/devices_one.ui
@@ -14,7 +14,16 @@
    <string>Form</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
-   <property name="margin">
+   <property name="leftMargin">
+    <number>0</number>
+   </property>
+   <property name="topMargin">
+    <number>0</number>
+   </property>
+   <property name="rightMargin">
+    <number>0</number>
+   </property>
+   <property name="bottomMargin">
     <number>0</number>
    </property>
    <item>
@@ -38,7 +47,7 @@
         <string>Add a row of setpoints</string>
        </property>
        <property name="icon">
-        <iconset resource="../../../resources/nicos-gui.qrc">
+        <iconset resource="../../../../resources/nicos-gui.qrc">
          <normaloff>:/add</normaloff>:/add</iconset>
        </property>
        <property name="iconSize">
@@ -55,7 +64,7 @@
         <string>Remove a row of setpoints</string>
        </property>
        <property name="icon">
-        <iconset resource="../../../resources/nicos-gui.qrc">
+        <iconset resource="../../../../resources/nicos-gui.qrc">
          <normaloff>:/remove</normaloff>:/remove</iconset>
        </property>
        <property name="iconSize">
@@ -88,7 +97,7 @@
         <string>Move current row up</string>
        </property>
        <property name="icon">
-        <iconset resource="../../../resources/nicos-gui.qrc">
+        <iconset resource="../../../../resources/nicos-gui.qrc">
          <normaloff>:/up</normaloff>:/up</iconset>
        </property>
        <property name="iconSize">
@@ -105,7 +114,7 @@
         <string>Move current row down</string>
        </property>
        <property name="icon">
-        <iconset resource="../../../resources/nicos-gui.qrc">
+        <iconset resource="../../../../resources/nicos-gui.qrc">
          <normaloff>:/down</normaloff>:/down</iconset>
        </property>
        <property name="iconSize">
@@ -135,7 +144,7 @@
         <string>Clear all rows and remove devices</string>
        </property>
        <property name="icon">
-        <iconset resource="../../../resources/nicos-gui.qrc">
+        <iconset resource="../../../../resources/nicos-gui.qrc">
          <normaloff>:/emergency</normaloff>:/emergency</iconset>
        </property>
        <property name="iconSize">
@@ -151,7 +160,7 @@
   </layout>
  </widget>
  <resources>
-  <include location="../../../resources/nicos-gui.qrc"/>
+  <include location="../../../../resources/nicos-gui.qrc"/>
  </resources>
  <connections/>
 </ui>

--- a/nicos_ess/loki/gui/ui_files/protocol.ui
+++ b/nicos_ess/loki/gui/ui_files/protocol.ui
@@ -14,11 +14,20 @@
    <string>Protocol generator</string>
   </property>
   <property name="windowIcon">
-   <iconset resource="../../../resources/nicos-gui.qrc">
+   <iconset resource="../../../../resources/nicos-gui.qrc">
     <normaloff>:/paste</normaloff>:/paste</iconset>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout_2">
-   <property name="margin">
+   <property name="leftMargin">
+    <number>0</number>
+   </property>
+   <property name="topMargin">
+    <number>0</number>
+   </property>
+   <property name="rightMargin">
+    <number>0</number>
+   </property>
+   <property name="bottomMargin">
     <number>0</number>
    </property>
    <item>
@@ -33,7 +42,7 @@
          <string>Generate</string>
         </property>
         <property name="icon">
-         <iconset resource="../../../resources/nicos-gui.qrc">
+         <iconset resource="../../../../resources/nicos-gui.qrc">
           <normaloff>:/down</normaloff>:/down</iconset>
         </property>
         <property name="iconSize">
@@ -158,7 +167,7 @@
            <string>Print</string>
           </property>
           <property name="icon">
-           <iconset resource="../../../resources/nicos-gui.qrc">
+           <iconset resource="../../../../resources/nicos-gui.qrc">
             <normaloff>:/print</normaloff>:/print</iconset>
           </property>
           <property name="iconSize">
@@ -205,7 +214,7 @@
            <string>Save</string>
           </property>
           <property name="icon">
-           <iconset resource="../../../resources/nicos-gui.qrc">
+           <iconset resource="../../../../resources/nicos-gui.qrc">
             <normaloff>:/save</normaloff>:/save</iconset>
           </property>
           <property name="iconSize">
@@ -249,7 +258,7 @@
   </layout>
   <action name="actionBack">
    <property name="icon">
-    <iconset resource="../../../resources/nicos-gui.qrc">
+    <iconset resource="../../../../resources/nicos-gui.qrc">
      <normaloff>:/previous</normaloff>:/previous</iconset>
    </property>
    <property name="text">
@@ -258,7 +267,7 @@
   </action>
   <action name="actionForward">
    <property name="icon">
-    <iconset resource="../../../resources/nicos-gui.qrc">
+    <iconset resource="../../../../resources/nicos-gui.qrc">
      <normaloff>:/next</normaloff>:/next</iconset>
    </property>
    <property name="text">
@@ -267,7 +276,7 @@
   </action>
   <action name="actionRefresh">
    <property name="icon">
-    <iconset resource="../../../resources/nicos-gui.qrc">
+    <iconset resource="../../../../resources/nicos-gui.qrc">
      <normaloff>:/refresh</normaloff>:/refresh</iconset>
    </property>
    <property name="text">
@@ -308,7 +317,7 @@
   </action>
   <action name="actionPrint">
    <property name="icon">
-    <iconset resource="../../../resources/nicos-gui.qrc">
+    <iconset resource="../../../../resources/nicos-gui.qrc">
      <normaloff>:/print</normaloff>:/print</iconset>
    </property>
    <property name="text">
@@ -327,7 +336,7 @@
   </customwidget>
  </customwidgets>
  <resources>
-  <include location="../../../resources/nicos-gui.qrc"/>
+  <include location="../../../../resources/nicos-gui.qrc"/>
  </resources>
  <connections/>
 </ui>

--- a/nicos_ess/loki/gui/ui_files/samples.ui
+++ b/nicos_ess/loki/gui/ui_files/samples.ui
@@ -61,7 +61,7 @@
         <string>Move highlighted samples into the Selected list</string>
        </property>
        <property name="icon">
-        <iconset resource="../../../resources/nicos-gui.qrc">
+        <iconset resource="../../../../resources/nicos-gui.qrc">
          <normaloff>:/next</normaloff>:/next</iconset>
        </property>
        <property name="iconSize">
@@ -78,7 +78,7 @@
         <string>Remove highlighted samples from the Selected list</string>
        </property>
        <property name="icon">
-        <iconset resource="../../../resources/nicos-gui.qrc">
+        <iconset resource="../../../../resources/nicos-gui.qrc">
          <normaloff>:/previous</normaloff>:/previous</iconset>
        </property>
        <property name="iconSize">
@@ -111,7 +111,7 @@
         <string>Clear Selected list</string>
        </property>
        <property name="icon">
-        <iconset resource="../../../resources/nicos-gui.qrc">
+        <iconset resource="../../../../resources/nicos-gui.qrc">
          <normaloff>:/emergency</normaloff>:/emergency</iconset>
        </property>
        <property name="iconSize">
@@ -144,7 +144,7 @@
         <string>Move sample up in the Selected list</string>
        </property>
        <property name="icon">
-        <iconset resource="../../../resources/nicos-gui.qrc">
+        <iconset resource="../../../../resources/nicos-gui.qrc">
          <normaloff>:/up</normaloff>:/up</iconset>
        </property>
        <property name="iconSize">
@@ -161,7 +161,7 @@
         <string>Move sample down in the Selected list</string>
        </property>
        <property name="icon">
-        <iconset resource="../../../resources/nicos-gui.qrc">
+        <iconset resource="../../../../resources/nicos-gui.qrc">
          <normaloff>:/down</normaloff>:/down</iconset>
        </property>
        <property name="iconSize">
@@ -304,7 +304,7 @@
   <tabstop>buttonBox</tabstop>
  </tabstops>
  <resources>
-  <include location="../../../resources/nicos-gui.qrc"/>
+  <include location="../../../../resources/nicos-gui.qrc"/>
  </resources>
  <connections>
   <connection>

--- a/nicos_ess/loki/gui/ui_files/table.ui
+++ b/nicos_ess/loki/gui/ui_files/table.ui
@@ -114,7 +114,16 @@
         <enum>QFrame::Plain</enum>
        </property>
        <layout class="QHBoxLayout" name="horizontalLayout_6">
-        <property name="margin">
+        <property name="leftMargin">
+         <number>0</number>
+        </property>
+        <property name="topMargin">
+         <number>0</number>
+        </property>
+        <property name="rightMargin">
+         <number>0</number>
+        </property>
+        <property name="bottomMargin">
          <number>0</number>
         </property>
        </layout>
@@ -424,7 +433,7 @@
   </layout>
  </widget>
  <resources>
-  <include location="../../../resources/nicos-gui.qrc"/>
+  <include location="../../../../resources/nicos-gui.qrc"/>
  </resources>
  <connections/>
 </ui>


### PR DESCRIPTION
Needed to add an extra `../` so Qt Designer can find the resource file for icons etc.

I don't think this matters for the GUI itself, but Qt Designer complained so I fixed it.