### PR TITLE
Reimplement connection status in title bar

### DIFF
--- a/nicos/clients/gui/mainwindow.py
+++ b/nicos/clients/gui/mainwindow.py
@@ -203,10 +203,6 @@ class MainWindow(DlgUtils, QMainWindow):
             lambda hide: self.setVisible(not hide))
         self.trayIcon.setContextMenu(self.trayMenu)
 
-        self.statusLabel = QLabel('', self, pixmap=QPixmap(':/disconnected'),
-                                  margin=5, minimumSize=QSize(30, 10))
-        self.toolBarMain.addWidget(self.statusLabel)
-
         # help window
         self.helpWindow = None
         # watchdog window
@@ -215,6 +211,14 @@ class MainWindow(DlgUtils, QMainWindow):
         self.pnpWindows = {}
 
         # create initial state
+        self._init_toolbar()
+
+    def _init_toolbar(self):
+        self.statusLabel = QLabel('', self, pixmap=QPixmap(':/disconnected'),
+                                  margin=5, minimumSize=QSize(30, 10))
+
+        self.toolbar = self.toolBarMain
+        self.toolbar.addWidget(self.statusLabel)
         self.setStatus('disconnected')
 
     def addPanel(self, panel, always=True):

--- a/nicos_ess/gui/mainwindow.py
+++ b/nicos_ess/gui/mainwindow.py
@@ -179,12 +179,15 @@ class MainWindow(DefaultMainWindow):
         is_connected = status != 'disconnected'
         if is_connected:
             self.actionConnect.setText('Disconnect')
+            self.statusLabel.setStyleSheet("color: lightgreen")
+            self.statusLabel.setText("Connected |")
         else:
             self.actionConnect.setText('Connect to server...')
+            self.statusLabel.setStyleSheet("color: red")
+            self.statusLabel.setText("Disconnected |")
             self.setTitlebar(False)
         # new status icon
         pixmap = QPixmap(':/' + status + ('exc' if exception else ''))
-        self.statusLabel.setPixmap(pixmap)
         self.statusLabel.setToolTip('Script status: %s' % status)
         new_icon = QIcon()
         new_icon.addPixmap(pixmap, QIcon.Disabled)

--- a/nicos_ess/gui/mainwindow.py
+++ b/nicos_ess/gui/mainwindow.py
@@ -84,7 +84,7 @@ class MainWindow(DefaultMainWindow):
     def _init_toolbar(self):
         self.statusLabel = QLabel('', self, pixmap=QPixmap(':/disconnected'),
                                   margin=5, minimumSize=QSize(30, 10))
-
+        self.statusLabel.setStyleSheet("color: white")
         self.toolbar = self.toolBarRight
         self.toolbar.addWidget(self.statusLabel)
         self.setStatus('disconnected')
@@ -187,11 +187,9 @@ class MainWindow(DefaultMainWindow):
         is_connected = status != 'disconnected'
         if is_connected:
             self.actionConnect.setText('Disconnect')
-            self.statusLabel.setStyleSheet("color: white")
             self.statusLabel.setText("\u2713 Connected")
         else:
             self.actionConnect.setText('Connect to server...')
-            self.statusLabel.setStyleSheet("color: white")
             self.statusLabel.setText("Disconnected")
             self.setTitlebar(False)
         # new status icon

--- a/nicos_ess/gui/mainwindow.py
+++ b/nicos_ess/gui/mainwindow.py
@@ -32,7 +32,7 @@ from time import time as current_time
 from nicos.clients.gui.dialogs.auth import ConnectionDialog
 from nicos.clients.gui.mainwindow import MainWindow as DefaultMainWindow
 from nicos.guisupport.qt import QApplication, QFileDialog, QIcon, QLabel, \
-    QMenu, QPixmap, QPoint, QSizePolicy, Qt, QWidget, pyqtSlot
+    QMenu, QPixmap, QPoint, QSizePolicy, Qt, QWidget, pyqtSlot, QSize
 
 from nicos_ess.gui import uipath
 from nicos_ess.gui.panels import get_icon
@@ -80,6 +80,14 @@ class MainWindow(DefaultMainWindow):
         self.actionUser.setMenu(dropdown)
         self.actionUser.setIconVisibleInMenu(True)
         self.dropdown = dropdown
+
+    def _init_toolbar(self):
+        self.statusLabel = QLabel('', self, pixmap=QPixmap(':/disconnected'),
+                                  margin=5, minimumSize=QSize(30, 10))
+
+        self.toolbar = self.toolBarRight
+        self.toolbar.addWidget(self.statusLabel)
+        self.setStatus('disconnected')
 
     def set_icons(self):
         self.actionUser.setIcon(
@@ -180,11 +188,11 @@ class MainWindow(DefaultMainWindow):
         if is_connected:
             self.actionConnect.setText('Disconnect')
             self.statusLabel.setStyleSheet("color: white")
-            self.statusLabel.setText("\u2713 Connected |")
+            self.statusLabel.setText("\u2713 Connected")
         else:
             self.actionConnect.setText('Connect to server...')
             self.statusLabel.setStyleSheet("color: white")
-            self.statusLabel.setText("Disconnected |")
+            self.statusLabel.setText("Disconnected")
             self.setTitlebar(False)
         # new status icon
         pixmap = QPixmap(':/' + status + ('exc' if exception else ''))

--- a/nicos_ess/gui/mainwindow.py
+++ b/nicos_ess/gui/mainwindow.py
@@ -179,11 +179,11 @@ class MainWindow(DefaultMainWindow):
         is_connected = status != 'disconnected'
         if is_connected:
             self.actionConnect.setText('Disconnect')
-            self.statusLabel.setStyleSheet("color: lightgreen")
-            self.statusLabel.setText("Connected |")
+            self.statusLabel.setStyleSheet("color: white")
+            self.statusLabel.setText("\u2713 Connected |")
         else:
             self.actionConnect.setText('Connect to server...')
-            self.statusLabel.setStyleSheet("color: red")
+            self.statusLabel.setStyleSheet("color: white")
             self.statusLabel.setText("Disconnected |")
             self.setTitlebar(False)
         # new status icon


### PR DESCRIPTION
This PR suggests a change in the main window in Nicos to clearly show the status of connection. Suggested change includes:

- If there is no connection, it is now written in red color "Disconnected"
- If there is a connection, it is now written in green color "Connected"

with clear separation characters to ease the eye. I believe this is better than the previous implementation with a signal LED, which was placed mis-aligned with the following text. 

Please do test and let me know if this is not good enough.