### PR TITLE
Experiment tab: disable and clear controls when disconnected

### DIFF
--- a/nicos_ess/loki/gui/setup_exp.py
+++ b/nicos_ess/loki/gui/setup_exp.py
@@ -138,6 +138,7 @@ class ExpPanel(Panel):
 
         self.notifEmails.setEnabled(not value)
         self.errorAbortBox.setEnabled(not value)
+        self.queryDBButton.setEnabled(not value)
 
     def on_client_experiment(self, data):
         # just reinitialize

--- a/nicos_ess/loki/gui/setup_exp.py
+++ b/nicos_ess/loki/gui/setup_exp.py
@@ -129,16 +129,16 @@ class ExpPanel(Panel):
         self.notifEmails.setPlainText("")
         self.setViewOnly(True)
 
-    def setViewOnly(self, value):
+    def setViewOnly(self, is_view_only):
         for button in self.buttonBox.buttons():
-            button.setEnabled(not value)
+            button.setEnabled(not is_view_only)
 
         for control in self._text_controls:
-            control.setEnabled(not value)
+            control.setEnabled(not is_view_only)
 
-        self.notifEmails.setEnabled(not value)
-        self.errorAbortBox.setEnabled(not value)
-        self.queryDBButton.setEnabled(not value)
+        self.notifEmails.setEnabled(not is_view_only)
+        self.errorAbortBox.setEnabled(not is_view_only)
+        self.queryDBButton.setEnabled(not is_view_only)
 
     def on_client_experiment(self, data):
         # just reinitialize
@@ -163,13 +163,12 @@ class ExpPanel(Panel):
         if local and local not in emails:
             emails.append(local)
         errorbehavior = 'abort' if self.errorAbortBox.isChecked() else 'report'
-        return prop, title, users, local, emails, [], errorbehavior
+        return prop, title, users, local, emails, errorbehavior
 
     @pyqtSlot()
     def on_queryDBButton_clicked(self):
         try:
-            prop, title, users, _, emails, dataEmails, \
-                _ = self._getProposalInput()
+            prop, title, users, _, emails, _ = self._getProposalInput()
         except ConfigurationError:
             return
 
@@ -223,7 +222,7 @@ class ExpPanel(Panel):
 
         # proposal settings
         try:
-            prop, title, users, local, email, dataEmails, errorbehavior = \
+            prop, title, users, local, email, errorbehavior = \
                 self._getProposalInput()
         except ConfigurationError:
             return
@@ -273,11 +272,7 @@ class ExpPanel(Panel):
             self.client.run('SetMailReceivers(%s)' %
                             ', '.join(map(repr, email)))
             done.append('New mail receivers set.')
-        if dataEmails != self._orig_datamails:
-            self.client.run('SetDataReceivers(%s)' %
-                            ', '.join(map(repr, dataEmails)))
-            done.append('New data mail receivers set.')
-        if errorbehavior != self._orig_proposal_info[5]:
+        if errorbehavior != self._orig_proposal_info[4]:
             self.client.run('SetErrorAbort(%s)' % (errorbehavior == 'abort'))
             done.append('New error behavior set.')
 

--- a/nicos_ess/loki/gui/setup_exp.py
+++ b/nicos_ess/loki/gui/setup_exp.py
@@ -60,6 +60,9 @@ class ExpPanel(Panel):
         self._new_exp_panel = options.get('new_exp_panel')
         self._finish_exp_panel = options.get('finish_exp_panel')
 
+        self._text_controls = (self.queryDBButton, self.proposalNum,
+                               self.expTitle, self.users, self.localContact,)
+
         # Hide proposal retrieval until available
         self.propdbInfo.setVisible(False)
         self.queryDBButton.setVisible(False)
@@ -101,7 +104,6 @@ class ExpPanel(Panel):
         self._orig_datamails = propinfo.get('user_email', '')
         if not isinstance(self._orig_datamails, list):
             self._orig_datamails = self._orig_datamails.splitlines()
-        self.dataEmails.setPlainText(decodeAny('\n'.join(self._orig_datamails)))
 
     def on_client_connected(self):
         # fill proposal
@@ -122,12 +124,20 @@ class ExpPanel(Panel):
         self.setViewOnly(self.client.viewonly)
 
     def on_client_disconnected(self):
+        for control in self._text_controls:
+            control.setText("")
+        self.notifEmails.setPlainText("")
         self.setViewOnly(True)
 
     def setViewOnly(self, value):
         for button in self.buttonBox.buttons():
             button.setEnabled(not value)
-        self.queryDBButton.setEnabled(not value)
+
+        for control in self._text_controls:
+            control.setEnabled(not value)
+
+        self.notifEmails.setEnabled(not value)
+        self.errorAbortBox.setEnabled(not value)
 
     def on_client_experiment(self, data):
         # just reinitialize
@@ -151,10 +161,8 @@ class ExpPanel(Panel):
         emails = emails.split('\n') if emails else []
         if local and local not in emails:
             emails.append(local)
-        dataEmails = self.dataEmails.toPlainText().strip()
-        dataEmails = dataEmails.split('\n') if dataEmails else []
         errorbehavior = 'abort' if self.errorAbortBox.isChecked() else 'report'
-        return prop, title, users, local, emails, dataEmails, errorbehavior
+        return prop, title, users, local, emails, [], errorbehavior
 
     @pyqtSlot()
     def on_queryDBButton_clicked(self):
@@ -183,8 +191,6 @@ class ExpPanel(Panel):
                 #                                                local)))
                 self.notifEmails.setPlainText(
                     decodeAny(result.get('user_email', emails)))
-                self.dataEmails.setPlainText(
-                    '\n'.join(decodeAny(addr) for addr in dataEmails))
                 # check permissions:
                 failed = []
                 yes = 'yes'

--- a/nicos_ess/loki/gui/ui_files/setup_exp.ui
+++ b/nicos_ess/loki/gui/ui_files/setup_exp.ui
@@ -92,15 +92,15 @@
         <layout class="QVBoxLayout" name="verticalLayout_2">
          <item>
           <layout class="QGridLayout" name="gridLayout">
-           <item row="5" column="0" colspan="2">
-            <widget class="Line" name="line_3">
-             <property name="orientation">
-              <enum>Qt::Horizontal</enum>
-             </property>
-            </widget>
-           </item>
            <item row="4" column="1">
             <widget class="QLineEdit" name="localContact"/>
+           </item>
+           <item row="7" column="1">
+            <widget class="QCheckBox" name="errorAbortBox">
+             <property name="text">
+              <string>Do not continue scripts after fatal errors</string>
+             </property>
+            </widget>
            </item>
            <item row="6" column="0">
             <widget class="QLabel" name="label_10">
@@ -121,6 +121,16 @@
              </property>
             </widget>
            </item>
+           <item row="2" column="0">
+            <widget class="QLabel" name="label_6">
+             <property name="text">
+              <string>Experiment title:</string>
+             </property>
+            </widget>
+           </item>
+           <item row="2" column="1">
+            <widget class="QLineEdit" name="expTitle"/>
+           </item>
            <item row="0" column="0" colspan="2">
             <widget class="Line" name="line">
              <property name="orientation">
@@ -128,10 +138,17 @@
              </property>
             </widget>
            </item>
-           <item row="4" column="0">
-            <widget class="QLabel" name="label_8">
+           <item row="3" column="0">
+            <widget class="QLabel" name="label_7">
              <property name="text">
-              <string>Local contact:</string>
+              <string>Users:</string>
+             </property>
+            </widget>
+           </item>
+           <item row="5" column="0" colspan="2">
+            <widget class="Line" name="line_3">
+             <property name="orientation">
+              <enum>Qt::Horizontal</enum>
              </property>
             </widget>
            </item>
@@ -157,58 +174,6 @@
              </property>
             </widget>
            </item>
-           <item row="7" column="0">
-            <widget class="QLabel" name="label_11">
-             <property name="sizePolicy">
-              <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
-               <horstretch>0</horstretch>
-               <verstretch>0</verstretch>
-              </sizepolicy>
-             </property>
-             <property name="text">
-              <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Send data&lt;br/&gt;(one email address &lt;br/&gt;per line):&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-             </property>
-             <property name="alignment">
-              <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
-             </property>
-             <property name="wordWrap">
-              <bool>true</bool>
-             </property>
-            </widget>
-           </item>
-           <item row="2" column="0">
-            <widget class="QLabel" name="label_6">
-             <property name="text">
-              <string>Experiment title:</string>
-             </property>
-            </widget>
-           </item>
-           <item row="2" column="1">
-            <widget class="QLineEdit" name="expTitle"/>
-           </item>
-           <item row="7" column="1">
-            <widget class="QPlainTextEdit" name="dataEmails">
-             <property name="sizePolicy">
-              <sizepolicy hsizetype="Expanding" vsizetype="Minimum">
-               <horstretch>0</horstretch>
-               <verstretch>0</verstretch>
-              </sizepolicy>
-             </property>
-             <property name="maximumSize">
-              <size>
-               <width>16777215</width>
-               <height>100</height>
-              </size>
-             </property>
-            </widget>
-           </item>
-           <item row="8" column="1">
-            <widget class="QCheckBox" name="errorAbortBox">
-             <property name="text">
-              <string>Do not continue scripts after fatal errors</string>
-             </property>
-            </widget>
-           </item>
            <item row="1" column="0" colspan="2">
             <widget class="QLabel" name="label_9">
              <property name="font">
@@ -227,15 +192,15 @@
              </property>
             </widget>
            </item>
-           <item row="3" column="1">
-            <widget class="QLineEdit" name="users"/>
-           </item>
-           <item row="3" column="0">
-            <widget class="QLabel" name="label_7">
+           <item row="4" column="0">
+            <widget class="QLabel" name="label_8">
              <property name="text">
-              <string>Users:</string>
+              <string>Local contact:</string>
              </property>
             </widget>
+           </item>
+           <item row="3" column="1">
+            <widget class="QLineEdit" name="users"/>
            </item>
           </layout>
          </item>


### PR DESCRIPTION
Changes to the setup_exp:
 * disable controls when view-only and disconnected
 * clear the text contents when disconnected
 * Removed send data textfield as that is not needed