### PR TITLE
Change emergency button icon

### DIFF
--- a/nicos_ess/gui/mainwindow.py
+++ b/nicos_ess/gui/mainwindow.py
@@ -112,7 +112,7 @@ class MainWindow(DefaultMainWindow):
     def set_icons(self):
         self.actionUser.setIcon(
             get_icon('settings_applications-24px.svg'))
-        self.actionEmergencyStop.setIcon(get_icon('emergency_stop-24px.svg'))
+        self.actionEmergencyStop.setIcon(get_icon('emergency_stop.svg'))
         self.actionConnect.setIcon(get_icon('power-24px.svg'))
         self.actionExit.setIcon(get_icon('exit_to_app-24px.svg'))
         self.actionViewOnly.setIcon(get_icon('lock-24px.svg'))

--- a/resources/material/icons/emergency_stop.svg
+++ b/resources/material/icons/emergency_stop.svg
@@ -1,0 +1,6 @@
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="24" height="24" viewBox="0,0,24,24">
+	<desc>close icon - Licensed under Apache License v2.0 (http://www.apache.org/licenses/LICENSE-2.0) - Created with Iconfu.com - Derivative work of Material icons (Copyright Google Inc.)</desc>
+	<g fill="#03b8e5" fill-rule="nonzero" style="mix-blend-mode: normal">
+		<path d="M13.41,12l5.59,5.59l-1.41,1.41l-5.59,-5.59l-5.59,5.59l-1.41,-1.41l5.59,-5.59l-5.59,-5.59l1.41,-1.41l5.59,5.59l5.59,-5.59l1.41,1.41z"/>
+	</g>
+</svg>


### PR DESCRIPTION
This PR proposes a material design for emergency stop button.

Note: The new icon does not require a license to be added as it is already in nicos/license with material.io Apache license. So we are good to go.