### PR TITLE
ECDC-2223: forward NICOS values to Kafka

### DIFF
--- a/bin/nicos-forwarder.py
+++ b/bin/nicos-forwarder.py
@@ -184,5 +184,4 @@ if __name__ == '__main__':
     SingleDeviceSession.run('forwarder', ForwarderApp,
                             {'prefix': 'nicos', 'cache': args.cache,
                              'brokers': args.brokers, 'topic': args.topic},
-
-                        pidfile=False)
+                            pidfile=False)

--- a/bin/nicos-forwarder.py
+++ b/bin/nicos-forwarder.py
@@ -67,7 +67,7 @@ class ForwarderApp(CacheClient):
             time.sleep(0.1)
 
     def getDeviceList(self, only_explicit=True, special_clause=None):
-        devlist = [key[:-6] for (key, _) in self.query_db('')
+        devlist = [key.replace('/value', '') for (key, _) in self.query_db('')
                    if key.endswith('/value')]
         if special_clause:
             devlist = [dn for dn in devlist

--- a/bin/nicos-forwarder.py
+++ b/bin/nicos-forwarder.py
@@ -1,16 +1,13 @@
-import argparse
-import logging
 import sys
 import time
 from os import path
 from threading import RLock
 
-from nicos.utils import createThread
-
 sys.path.insert(0, path.dirname(path.dirname(path.realpath(__file__))))
 
-from nicos.devices.cacheclient import CacheClient
 from nicos.core.sessions.simple import SingleDeviceSession
+from nicos.devices.cacheclient import CacheClient
+from nicos.utils import createThread
 
 # TODO: for f142 only send status/severity if it changes otherwise send NO_CHANGE
 # Are only OK, WARN and ERROR relevant? UNKNOWN?

--- a/bin/nicos-forwarder.py
+++ b/bin/nicos-forwarder.py
@@ -9,7 +9,9 @@ from typing import Any, Tuple
 
 from kafka import KafkaProducer
 from streaming_data_types.logdata_f142 import serialise_f142
-from streaming_data_types.fbschemas.logdata_f142.AlarmSeverity import AlarmSeverity
+from streaming_data_types.fbschemas.logdata_f142.AlarmSeverity import \
+    AlarmSeverity
+from streaming_data_types.fbschemas.logdata_f142.AlarmStatus import AlarmStatus
 
 sys.path.insert(0, path.dirname(path.dirname(path.realpath(__file__))))
 
@@ -143,7 +145,9 @@ class ForwarderApp(CacheClient):
 
     @staticmethod
     def _to_f142(name, value, timestamp, severity):
-        return serialise_f142(value, name, timestamp, alarm_severity=severity)
+        # Alarm status is not relevant for NICOS but we have to send something
+        return serialise_f142(value, name, timestamp, AlarmStatus.NO_ALARM,
+                              severity)
 
     def send_to_kafka(self, buffer):
         self._producer.send(self._config['topic'], buffer)

--- a/bin/nicos-forwarder.py
+++ b/bin/nicos-forwarder.py
@@ -160,7 +160,7 @@ class ForwarderApp(CacheClient):
 
     def send_to_kafka(self, buffer):
         self._producer.send(self._config['topic'], buffer)
-        self._producer.flush()
+        self._producer.flush(timeout=3)
 
 
 if __name__ == '__main__':

--- a/bin/nicos-forwarder.py
+++ b/bin/nicos-forwarder.py
@@ -1,16 +1,35 @@
 import sys
 import time
+from dataclasses import dataclass
 from os import path
 from threading import RLock
+from time import time_ns
+from typing import Any, Tuple
+
+from nicos.core import status
 
 sys.path.insert(0, path.dirname(path.dirname(path.realpath(__file__))))
 
+from kafka import KafkaProducer
 from nicos.core.sessions.simple import SingleDeviceSession
 from nicos.devices.cacheclient import CacheClient
 from nicos.utils import createThread
+from streaming_data_types.logdata_f142 import serialise_f142
+from streaming_data_types.fbschemas.logdata_f142.AlarmSeverity import AlarmSeverity
 
-# TODO: for f142 only send status/severity if it changes otherwise send NO_CHANGE
-# Are only OK, WARN and ERROR relevant? UNKNOWN?
+
+# Treat everything that is not WARN or ERROR as OK
+nicos_status_to_f142 = {
+    status.OK: AlarmSeverity.NO_ALARM,
+    status.WARN: AlarmSeverity.MINOR,
+    status.ERROR: AlarmSeverity.MAJOR,
+}
+
+
+@dataclass
+class DeviceState:
+    value: Any
+    status: int
 
 
 class ForwarderApp(CacheClient):
@@ -49,30 +68,55 @@ class ForwarderApp(CacheClient):
     def create_callbacks(self, devices):
         for dev in devices:
             self.log.info(f'Added {dev}')
-            current_status = self.getDeviceParam(dev, 'status')
+            current_status = self._convert_status(self.getDeviceParam(dev, 'status'))
             current_value = self.getDeviceParam(dev, 'value')
-            self._status_value_cache[dev] = [current_status, current_value]
-            self.addCallback(dev, 'status', self.changed_value_callback)
+            # TODO: send initial values to kafka
+            self._status_value_cache[dev] = \
+                DeviceState(current_status, current_value)
+            self.addCallback(dev, 'status', self.change_status_callback)
             self.addCallback(dev, 'value', self.changed_value_callback)
 
-    def changed_value_callback(self, name, value, timestamp, *args, **kwargs):
+    @staticmethod
+    def _convert_status(nicos_status):
+        return nicos_status_to_f142.get(nicos_status[0], AlarmSeverity.NO_ALARM)
+
+    def changed_value_callback(self, name, new_value, timestamp_s, *args, **kwargs):
         dev_name = name[0:name.index('/')]
-        if name.endswith('/status'):
-            self.log.info(f'{dev_name} status changed to {value}')
-            with self._lock:
-                self._status_value_cache[dev_name][0] = value
-            # TODO: send value and new status
-        elif name.endswith('/value'):
-            self.log.info(f'{dev_name} value changed to {value}')
-            with self._lock:
-                self._status_value_cache[dev_name][1] = value
-            # TODO: send value with no change in status
+        self.log.info(f'{dev_name} value changed to {new_value}')
+        with self._lock:
+            self._status_value_cache[dev_name].value = new_value
+        buffer = self._to_f142(dev_name, new_value, int(timestamp_s * 10 ** 9),
+                               AlarmSeverity.NO_CHANGE)
+        self.send_to_kafka(buffer)
+
+    def change_status_callback(self, name, new_status, timestamp_s, *args, **kwargs):
+        dev_name = name[0:name.index('/')]
+        self.log.info(f'{dev_name} status changed to {new_status}')
+        new_status = self._convert_status(new_status)
+        with self._lock:
+            if new_status == self._status_value_cache[dev_name].status:
+                # No change so nothing to do
+                return
+            self._status_value_cache[dev_name].status = new_status
+            value = self._status_value_cache[dev_name].value
+        buffer = self._to_f142(dev_name, value, int(timestamp_s * 10 ** 9),
+                               new_status)
+        # self.send_to_kafka(buffer)
+
+    @staticmethod
+    def _to_f142(name, value, timestamp, severity):
+        return serialise_f142(value, name, timestamp, alarm_severity=severity)
+
+    def send_to_kafka(self, buffer):
+        self._producer.send("nicos_forwarder_test", buffer)
+        self._producer.flush()
 
     def doInit(self, mode):
         CacheClient.doInit(self, mode)
         self._status_value_cache = {}
         self._current_devices = set()
         self._lock = RLock()
+        self._producer = KafkaProducer(bootstrap_servers=["localhost:9092"])
 
         # Wait until connected
         while not self.getDeviceList():

--- a/bin/nicos-forwarder.py
+++ b/bin/nicos-forwarder.py
@@ -1,0 +1,99 @@
+import argparse
+import logging
+import sys
+import time
+from os import path
+from threading import RLock
+
+from nicos.utils import createThread
+
+sys.path.insert(0, path.dirname(path.dirname(path.realpath(__file__))))
+
+from nicos.devices.cacheclient import CacheClient
+from nicos.core.sessions.simple import SingleDeviceSession
+
+# TODO: for f142 only send status/severity if it changes otherwise send NO_CHANGE
+# Are only OK, WARN and ERROR relevant? UNKNOWN?
+
+
+class ForwarderApp(CacheClient):
+    _status_value_cache = {}
+    _current_devices = set()
+    _device_watcher = None
+    _lock = RLock()
+
+    def start(self, *args):
+        self._device_watcher = createThread('device watcher', self.device_thread,
+                                            start=False)
+        self._device_watcher.start()
+
+    def device_thread(self):
+        while True:
+            try:
+                devices = set(self.getDeviceList())
+                if devices != self._current_devices:
+                    self.log.info('Device list changed')
+                    with self._lock:
+                        self.remove_current_callbacks()
+                        self._status_value_cache.clear()
+                        self.create_callbacks(devices)
+                        self._current_devices = devices
+                time.sleep(0.1)
+            except Exception:
+                self.log.exception('exception in device watcher thread')
+                if self._stoprequest:
+                    break  # ensure we do not restart during shutdown
+
+    def remove_current_callbacks(self):
+        for dev in self._current_devices:
+            self.removeCallback(dev, 'status', self.changed_value_callback)
+            self.removeCallback(dev, 'value', self.changed_value_callback)
+
+    def create_callbacks(self, devices):
+        for dev in devices:
+            self.log.info(f'Added {dev}')
+            current_status = self.getDeviceParam(dev, 'status')
+            current_value = self.getDeviceParam(dev, 'value')
+            self._status_value_cache[dev] = [current_status, current_value]
+            self.addCallback(dev, 'status', self.changed_value_callback)
+            self.addCallback(dev, 'value', self.changed_value_callback)
+
+    def changed_value_callback(self, name, value, timestamp, *args, **kwargs):
+        dev_name = name[0:name.index('/')]
+        if name.endswith('/status'):
+            self.log.info(f'{dev_name} status changed to {value}')
+            with self._lock:
+                self._status_value_cache[dev_name][0] = value
+            # TODO: send value and new status
+        elif name.endswith('/value'):
+            self.log.info(f'{dev_name} value changed to {value}')
+            with self._lock:
+                self._status_value_cache[dev_name][1] = value
+            # TODO: send value with no change in status
+
+    def doInit(self, mode):
+        CacheClient.doInit(self, mode)
+        self._status_value_cache = {}
+        self._current_devices = set()
+        self._lock = RLock()
+
+        # Wait until connected
+        while not self.getDeviceList():
+            time.sleep(0.1)
+
+    def getDeviceList(self, only_explicit=True, special_clause=None):
+        devlist = [key[:-6] for (key, _) in self.query_db('')
+                   if key.endswith('/value')]
+        if special_clause:
+            devlist = [dn for dn in devlist
+                       if eval(special_clause, {'dn': dn})]
+        return sorted(devlist)
+
+    def getDeviceParam(self, devname, parname):
+        return self.get(devname, parname)
+
+
+if __name__ == '__main__':
+    SingleDeviceSession.run('forwarder', ForwarderApp,
+                        {'prefix': 'nicos', 'cache': 'localhost'},
+                        pidfile=False)

--- a/bin/nicos-forwarder.py
+++ b/bin/nicos-forwarder.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass
 from os import path
 from threading import RLock
 from time import time_ns
-from typing import Any, Tuple
+from typing import Any
 
 from kafka import KafkaProducer
 from streaming_data_types.logdata_f142 import serialise_f142
@@ -57,9 +57,9 @@ class ForwarderApp(CacheClient):
                     f'Could not connect to Kafka - will try again soon: {error}'
                 )
                 time.sleep(5)
-        self.log.info(f"Connected to Kafka brokers {self._config['brokers']}")
+        self.log.info(f'Connected to Kafka brokers {self._config["brokers"]}')
 
-        # Wait until connected
+        # Wait until connected to nicos
         while not self.getDeviceList():
             time.sleep(0.1)
 
@@ -92,8 +92,9 @@ class ForwarderApp(CacheClient):
                         self.create_callbacks(devices)
                         self._current_devices = devices
                 time.sleep(0.1)
-            except Exception:
-                self.log.exception('exception in device watcher thread')
+            except Exception as error:
+                self.log.exception(
+                    f'exception in device watcher thread {error}')
                 if self._stoprequest:
                     break  # ensure we do not restart during shutdown
 


### PR DESCRIPTION
This uses a new service to get the values from NICOS and send them to Kafka.
I think it is cleaner than doing it in NICOS itself as it allows the NICOS cache just to run as normal.