### PR TITLE
LoKI: Warn if thickness is zero

### DIFF
--- a/nicos_ess/loki/gui/sampleconf.py
+++ b/nicos_ess/loki/gui/sampleconf.py
@@ -138,7 +138,7 @@ class ConfigEditDialog(QDialog):
                                                'one.')
             self.frm.nameBox.setFocus()
             return
-        if self.frm.thickBox.text() == '0.0':
+        if float(self.frm.thickBox.text()) == 0:
             QMessageBox.warning(self, 'Error', 'Thickness cannot be zero.')
             self.thickBox.setFocus()
             return

--- a/nicos_ess/loki/gui/sampleconf.py
+++ b/nicos_ess/loki/gui/sampleconf.py
@@ -138,6 +138,10 @@ class ConfigEditDialog(QDialog):
                                                'one.')
             self.frm.nameBox.setFocus()
             return
+        if self.frm.thickBox.text() == '0.0':
+            QMessageBox.warning(self, 'Error', 'Thickness cannot be zero.')
+            self.thickBox.setFocus()
+            return
         for box in [self.frm.offsetBox, self.frm.thickBox, self.frm.apXBox,
                     self.frm.apYBox, self.frm.apWBox, self.frm.apHBox]:
             if not box.text():


### PR DESCRIPTION
This PR adds a warning to the sample config UI if the `thickness` is equal to zero. The next check already handles if it is `None`. 