### PR TITLE
LoKI: Enable apply button if there are changes

### DIFF
--- a/nicos_ess/loki/gui/sampleconf.py
+++ b/nicos_ess/loki/gui/sampleconf.py
@@ -285,8 +285,12 @@ class LokiSamplePanel(Panel):
         ]:
             control.setEnabled(not viewonly)
             # Handle apply button separately.
-            if viewonly:
-                self.applyBtn.setEnabled(False)
+        if viewonly:
+            self.applyBtn.setEnabled(False)
+        # If one toggles view only mode without applying changes, upon exiting
+        # view-only mode, following ensures apply button is enabled.
+        if self.dirty and not viewonly:
+            self.applyBtn.setEnabled(True)
 
     @pyqtSlot()
     def on_actionEmpty_triggered(self):

--- a/nicos_ess/loki/gui/sampleconf.py
+++ b/nicos_ess/loki/gui/sampleconf.py
@@ -289,7 +289,7 @@ class LokiSamplePanel(Panel):
             self.applyBtn.setEnabled(False)
         # If one toggles view only mode without applying changes, upon exiting
         # view-only mode, following ensures apply button is enabled.
-        if self.dirty and not viewonly:
+        elif self.dirty and not viewonly:
             self.applyBtn.setEnabled(True)
 
     @pyqtSlot()

--- a/nicos_ess/loki/gui/sampleconf.py
+++ b/nicos_ess/loki/gui/sampleconf.py
@@ -289,7 +289,7 @@ class LokiSamplePanel(Panel):
             self.applyBtn.setEnabled(False)
         # If one toggles view only mode without applying changes, upon exiting
         # view-only mode, following ensures apply button is enabled.
-        elif self.dirty and not viewonly:
+        elif self.dirty:
             self.applyBtn.setEnabled(True)
 
     @pyqtSlot()

--- a/nicos_ess/loki/gui/sampleconf.py
+++ b/nicos_ess/loki/gui/sampleconf.py
@@ -624,7 +624,6 @@ class LokiSamplePanel(Panel):
         self.applyBtn.setEnabled(True)
 
 
-
 class MockSample:
     def __init__(self):
         self.reset_called = False

--- a/nicos_ess/loki/gui/sampleconf.py
+++ b/nicos_ess/loki/gui/sampleconf.py
@@ -257,6 +257,7 @@ class LokiSamplePanel(Panel):
 
         self.configs = []
         self.dirty = False
+        self.applyBtn.setEnabled(False)
         self.holder_info = options.get('holder_info', [])
         self.instrument = options.get('instrument', 'loki')
 
@@ -278,11 +279,14 @@ class LokiSamplePanel(Panel):
 
     def setViewOnly(self, viewonly):
         for control in [
-            self.createBtn, self.retrieveBtn, self.openFileBtn, self.applyBtn,
+            self.createBtn, self.retrieveBtn, self.openFileBtn,
             self.saveBtn, self.newBtn, self.editBtn, self.delBtn, self.frame,
             self.list
         ]:
             control.setEnabled(not viewonly)
+            # Handle apply button separately.
+            if viewonly:
+                self.applyBtn.setEnabled(False)
 
     @pyqtSlot()
     def on_actionEmpty_triggered(self):
@@ -362,7 +366,7 @@ class LokiSamplePanel(Panel):
         self.on_list_itemClicked(first_item)
 
         self.sampleGroup.setEnabled(True)
-        self.dirty = True
+        self._set_dirty()
 
     def _generate_configs(self, dlg):
         rows, levels, ax1, dax1, ax2, dax2 = dlg._info
@@ -441,11 +445,13 @@ class LokiSamplePanel(Panel):
 
     @pyqtSlot()
     def on_applyBtn_clicked(self):
-        if self.dirty:
+        if self.dirty:  # Remains as a validator
             script = self._generate_script()
             self.client.run(script)
             self.showInfo('Sample info has been transferred to the daemon.')
         self.dirty = False
+        # Disable apply button
+        self.applyBtn.setEnabled(False)
 
     @pyqtSlot()
     def on_saveBtn_clicked(self):
@@ -510,12 +516,12 @@ class LokiSamplePanel(Panel):
             box.setValidator(DoubleValidator(self))
 
     def set_offset(self, i, val):
-        self.dirty = True
+        self._set_dirty()
         self.configs[i]['detoffset'] = val
         self._copy_key('detoffset')
 
     def set_aperture(self, i, val, key):
-        self.dirty = True
+        self._set_dirty()
         # The following implementation is required as "aperture" has been
         # implemented as a tuple rather then a simple list.
         x = self.configs[i]['aperture'][0]
@@ -541,7 +547,7 @@ class LokiSamplePanel(Panel):
                                self.configs)
         if not dlg.exec_():
             return
-        self.dirty = True
+        self._set_dirty()
         config = configFromFrame(dlg.frm)
         self.configs.append(config)
         new_item = QListWidgetItem(config['name'], self.list)
@@ -558,7 +564,7 @@ class LokiSamplePanel(Panel):
                                self.configs[index])
         if not dlg.exec_():
             return
-        self.dirty = True
+        self._set_dirty()
         config = configFromFrame(dlg.frm)
         self.configs[index] = config
         list_item = self.list.item(index)
@@ -570,7 +576,7 @@ class LokiSamplePanel(Panel):
         index = self.list.currentRow()
         if index < 0:
             return
-        self.dirty = True
+        self._set_dirty()
         self.list.takeItem(index)
         del self.configs[index]
         if self.list.currentRow() != -1:
@@ -582,7 +588,7 @@ class LokiSamplePanel(Panel):
         index = self.list.currentRow()
         if index < 0:
             return
-        self.dirty = True
+        self._set_dirty()
         template = self.configs[index][key]
         for config in self.configs:
             config[key] = template
@@ -604,6 +610,15 @@ class LokiSamplePanel(Panel):
     def _save_script(filename, script):
         with open(filename, 'w') as fp:
             fp.writelines(script)
+
+    def _set_dirty(self):
+        """
+        Enables apply changes button if there are changes in the sample
+        configuration.
+        """
+        self.dirty = True
+        self.applyBtn.setEnabled(True)
+
 
 
 class MockSample:

--- a/nicos_ess/loki/gui/sampleconf.py
+++ b/nicos_ess/loki/gui/sampleconf.py
@@ -454,7 +454,6 @@ class LokiSamplePanel(Panel):
             self.client.run(script)
             self.showInfo('Sample info has been transferred to the daemon.')
         self.dirty = False
-        # Disable apply button
         self.applyBtn.setEnabled(False)
 
     @pyqtSlot()


### PR DESCRIPTION
This PR makes sure that `Apply Changes` button is enabled if and only if there are changes in the sample configurations. 