### PR TITLE
Add starting the nicos-forwarder as part of the YMIR tmux-script

### DIFF
--- a/bin/nicos-forwarder
+++ b/bin/nicos-forwarder
@@ -1,3 +1,28 @@
+#!/usr/bin/env python
+#  -*- coding: utf-8 -*-
+# *****************************************************************************
+# NICOS, the Networked Instrument Control System of the MLZ
+# Copyright (c) 2009-2021 by the NICOS contributors (see AUTHORS)
+#
+# This program is free software; you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software
+# Foundation; either version 2 of the License, or (at your option) any later
+# version.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc.,
+# 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#
+# Module authors:
+#   Matt Clarke <matt.clarke@ess.eu>
+#
+# *****************************************************************************
+
 import argparse
 import sys
 import time

--- a/tmux_scripts/start_nicos_ymir.sh
+++ b/tmux_scripts/start_nicos_ymir.sh
@@ -24,3 +24,10 @@ tmux send-keys "export EPICS_CA_ADDR_LIST='172.30.238.79'" C-m
 tmux send-keys "export EPICS_PVA_AUTO_ADDR_LIST=NO" C-m
 tmux send-keys "export EPICS_PVA_ADDR_LIST='172.30.238.79'" C-m
 tmux send-keys "bin/nicos-daemon" C-m
+
+tmux new-window -t $session:4 -n forwarder
+tmux send-keys "export EPICS_CA_AUTO_ADDR_LIST=NO" C-m
+tmux send-keys "export EPICS_CA_ADDR_LIST='172.30.238.79'" C-m
+tmux send-keys "export EPICS_PVA_AUTO_ADDR_LIST=NO" C-m
+tmux send-keys "export EPICS_PVA_ADDR_LIST='172.30.238.79'" C-m
+tmux send-keys "bin/nicos-forwarder -b 172.30.242.20:9092 -t ymir_nicos_devices" C-m


### PR DESCRIPTION
This should be running at all times for YMIR from now on.