### PR TITLE
ECDC-2335: Replace buttonbox with PushButton in LoKi exp setup

### DIFF
--- a/nicos_ess/loki/gui/setup_exp.py
+++ b/nicos_ess/loki/gui/setup_exp.py
@@ -212,9 +212,6 @@ class ExpPanel(Panel):
                           'Please check logfiles....\n' + repr(e))
 
     def on_applyBtn_clicked(self):
-        self.applyChanges()
-
-    def applyChanges(self):
         done = []
 
         # proposal settings

--- a/nicos_ess/loki/gui/setup_exp.py
+++ b/nicos_ess/loki/gui/setup_exp.py
@@ -63,6 +63,7 @@ class ExpPanel(Panel):
         self._text_controls = (self.queryDBButton, self.proposalNum,
                                self.expTitle, self.users, self.localContact,)
 
+        self.applyBtn.clicked.connect(self.on_applyBtn_clicked)
         # Hide proposal retrieval until available
         self.propdbInfo.setVisible(False)
         self.queryDBButton.setVisible(False)
@@ -132,15 +133,13 @@ class ExpPanel(Panel):
         self.setViewOnly(True)
 
     def setViewOnly(self, is_view_only):
-        for button in self.buttonBox.buttons():
-            button.setEnabled(not is_view_only)
-
         for control in self._text_controls:
             control.setEnabled(not is_view_only)
 
         self.notifEmails.setEnabled(not is_view_only)
         self.errorAbortBox.setEnabled(not is_view_only)
         self.queryDBButton.setEnabled(not is_view_only)
+        self.applyBtn.setEnabled(not is_view_only)
 
     def on_client_experiment(self, data):
         # just reinitialize
@@ -212,12 +211,8 @@ class ExpPanel(Panel):
             self.showInfo('Reading proposaldb failed for an unknown reason. '
                           'Please check logfiles....\n' + repr(e))
 
-    def on_buttonBox_clicked(self, button):
-        role = self.buttonBox.buttonRole(button)
-        if role == QDialogButtonBox.ApplyRole:
-            self.applyChanges()
-        elif role == QDialogButtonBox.RejectRole:
-            self.closeWindow()
+    def on_applyBtn_clicked(self):
+        self.applyChanges()
 
     def applyChanges(self):
         done = []

--- a/nicos_ess/loki/gui/ui_files/setup_exp.ui
+++ b/nicos_ess/loki/gui/ui_files/setup_exp.ui
@@ -23,19 +23,6 @@
       <enum>QFrame::Raised</enum>
      </property>
      <layout class="QFormLayout" name="formLayout">
-      <item row="2" column="0">
-       <spacer name="verticalSpacer">
-        <property name="orientation">
-         <enum>Qt::Vertical</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>0</width>
-          <height>20</height>
-         </size>
-        </property>
-       </spacer>
-      </item>
       <item row="0" column="0" colspan="2">
        <widget class="QWidget" name="newBox" native="true">
         <layout class="QGridLayout" name="gridLayout_3">
@@ -221,15 +208,43 @@
         </layout>
        </widget>
       </item>
-      <item row="3" column="0" colspan="2">
-       <widget class="QDialogButtonBox" name="buttonBox">
+      <item row="3" column="1">
+       <widget class="QPushButton" name="applyBtn">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
         <property name="layoutDirection">
          <enum>Qt::RightToLeft</enum>
         </property>
-        <property name="standardButtons">
-         <set>QDialogButtonBox::Apply</set>
+        <property name="text">
+         <string>Apply changes</string>
+        </property>
+        <property name="autoDefault">
+         <bool>false</bool>
+        </property>
+        <property name="default">
+         <bool>true</bool>
+        </property>
+        <property name="flat">
+         <bool>false</bool>
         </property>
        </widget>
+      </item>
+      <item row="2" column="1">
+       <spacer name="verticalSpacer">
+        <property name="orientation">
+         <enum>Qt::Vertical</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>20</width>
+          <height>40</height>
+         </size>
+        </property>
+       </spacer>
       </item>
      </layout>
     </widget>


### PR DESCRIPTION
This replaces `dialogButtonBox` with `QPushButton` in the Experiment panel of LoKI gui. 