### PR TITLE
ECDC-2340: Missing method in EpicsKafkaForwarderControl

### DIFF
--- a/nicos_ess/devices/forwarder.py
+++ b/nicos_ess/devices/forwarder.py
@@ -113,11 +113,9 @@ class EpicsKafkaForwarderControl(ProducesKafkaMessages, Device):
                 pv = stream["channel_name"]
                 pvs_read.append(pv)
                 if pv in issued:
-                    forwarding = is_forwarding(issued[pv][0], issued[pv][1],
-                        stream["converters"])
+                    forwarding = is_forwarding(issued[pv][0], issued[pv][1], stream["converters"])
                     if not forwarding:
                         not_forwarded.append(pv)
-
             not_forwarded += [pv for pv in issued if pv not in pvs_read]
             return not_forwarded
 
@@ -161,13 +159,17 @@ class EpicsKafkaForwarderControl(ProducesKafkaMessages, Device):
                                       topic or self.instpvtopic,
                 Protocol.Protocol.CA, ) for pv, (topic, schema) in
                 pv_details.items()]
-            self._issued.update({pv: (topic, schema) for pv, (topic, schema) in
-                pv_details.items()})  # update issued
+            self._issued.update(
+                {pv: (topic or self.instpvtopic, schema or self.instpvschema) 
+                 for pv, (topic, schema) in pv_details.items()})  # update issued
         except KeyError as e:
             self.log.warning(e)
             return
         buff = serialise_rf5k(config_change, streams)
         self.send(self.cmdtopic, buff)
+    
+    def pv_forwarding_info(self, pv):
+        return self._issued.get(pv, None)
 
     def reissue(self):
         self.add(self._issued)
@@ -255,7 +257,7 @@ class EpicsKafkaForwarder(KafkaStatusHandler):
         non-empty value only if the forwarder_control is present.
         """
         if self._attached_forwarder_control:
-            return self._attached_forwarder_control.self._notforwarding
+            return self._attached_forwarder_control._notforwarding
         return None
 
     def add(self, pv_details):

--- a/nicos_ess/devices/forwarder.py
+++ b/nicos_ess/devices/forwarder.py
@@ -35,18 +35,6 @@ from nicos_ess.devices.kafka.producer import ProducesKafkaMessages
 from nicos_ess.devices.kafka.status_handler import KafkaStatusHandler
 
 
-def is_forwarding(topic, schema, converters):
-    # Must check that the topic and schema match as the same PV could be
-    # forwarded multiple times with different settings.
-    for converter in converters:
-        full_uri = f'{converter["broker"]}/{converter["topic"]}'
-        name_present = converter["topic"] == topic or topic.endswith(full_uri)
-        schema_present = converter["schema"] == schema
-        if name_present and schema_present:
-            return True
-    return False
-
-
 class EpicsKafkaForwarderControl(ProducesKafkaMessages, Device):
     """ Configures the EPICS to Kafka forwarder
 
@@ -112,13 +100,7 @@ class EpicsKafkaForwarderControl(ProducesKafkaMessages, Device):
                 pv = stream["channel_name"]
                 pvs_read.append(pv)
                 if pv in issued:
-                    try:
-                         # 'converters' key doesn't exist in stream. Legacy?
-                        forwarding = is_forwarding(issued[pv][0], issued[pv][1],
-                            stream["converters"])
-                    except KeyError:
-                        forwarding = issued[pv][0] == stream["output_topic"] and issued[pv][1] == stream["schema"]
-
+                    forwarding = issued[pv][0] == stream["output_topic"] and issued[pv][1] == stream["schema"]
                     if not forwarding:
                         not_forwarded.append(pv)
             not_forwarded += [pv for pv in issued if pv not in pvs_read]
@@ -128,34 +110,6 @@ class EpicsKafkaForwarderControl(ProducesKafkaMessages, Device):
             self._notforwarding = set(get_not_forwarding(message, self._issued))
 
         self.doStatus()
-
-    def add_legacy(self, pv_details):
-        """ Configure given PVs to start forwarding. Specific topics and
-        schemas can be provided. If not, default instrument topic and
-        schemas will be used.
-        :param pv_details: PVs and the tuple of (topic, schema)
-        :type pv_details: dict(pvname, (kafka-topic, schema))
-        """
-        streams = []
-        for pv in pv_details:
-            topic, schema = pv_details[pv]
-            if not topic:
-                topic = self.instpvtopic
-            if not schema:
-                schema = self.instpvschema
-
-            self._issued[pv] = (topic, schema)
-
-            for broker in self.brokers:
-                converter = {'topic': f'{broker}/{topic}', 'schema': schema, }
-                stream = {'converter': converter,
-                          'channel_provider_type': 'ca',
-                          'channel': pv, }
-                streams.append(stream)
-
-        cmd = {'cmd': 'add', 'streams': streams}
-
-        self.send(self.cmdtopic, json.dumps(cmd).encode())
 
     def add(self, pv_details):
         try:

--- a/test/nicos_ess/test_devices/test_forwarder.py
+++ b/test/nicos_ess/test_devices/test_forwarder.py
@@ -55,7 +55,7 @@ session_setup = 'ess_forwarder'
 
 
 def create_stream(
-    pv, protocol='CA', topic='TEST_metadata', schema='f142'
+    pv, protocol='ca', topic='TEST_metadata', schema='f142'
 ):
     return {
         'channel_name': pv,
@@ -115,27 +115,6 @@ def create_pv_details_from_messages(messages):
             stream['schema'],
         )
     return pv_details
-
-
-def create_command_from_messages(messages):
-    streams = messages[sorted(list(messages.keys()))[-1]].get('streams', [])
-    command = {'cmd': 'add', 'streams': []}
-
-    def get_stream_entry(ch, conv):
-        return {
-            'converter': {
-                'topic': f'{conv["broker"]}/{conv["topic"]}',
-                'schema': conv['schema'],
-            },
-            'channel_provider_type': 'ca',
-            'channel': ch,
-        }
-
-    for stream in streams:
-        converter = stream['converters'][0]
-        channel = stream['channel_name']
-        command['streams'].append(get_stream_entry(channel, converter))
-    return command
 
 
 class TestEpicsKafkaForwarderStatus(TestCase):

--- a/test/nicos_ess/test_devices/test_forwarder.py
+++ b/test/nicos_ess/test_devices/test_forwarder.py
@@ -55,11 +55,13 @@ session_setup = 'ess_forwarder'
 
 
 def create_stream(
-    pv, broker='localhost:9092', topic='TEST_metadata', schema='f142'
+    pv, protocol='CA', topic='TEST_metadata', schema='f142'
 ):
     return {
         'channel_name': pv,
-        'converters': [{'broker': broker, 'topic': topic, 'schema': schema}],
+        "protocol": protocol,
+        "output_topic": topic,
+        "schema": schema,
     }
 
 
@@ -93,10 +95,9 @@ def create_issued_from_messages(messages):
     streams = messages[sorted(list(messages.keys()))[-1]].get('streams', [])
     issued = {}
     for stream in streams:
-        converter = stream['converters'][0]
         issued[stream['channel_name']] = (
-            converter['topic'],
-            converter['schema'],
+            stream['output_topic'],
+            stream['schema'],
         )
     return issued
 
@@ -109,10 +110,9 @@ def create_pv_details_from_messages(messages):
     streams = messages[sorted(list(messages.keys()))[-1]].get('streams', [])
     pv_details = {}
     for stream in streams:
-        converter = stream['converters'][0]
         pv_details[stream['channel_name']] = (
-            converter['topic'],
-            converter['schema'],
+            stream['output_topic'],
+            stream['schema'],
         )
     return pv_details
 


### PR DESCRIPTION
This PR 

- Deal with status message stream from the forwarder which does not contain `converters` key.  
- Add `pv_forwarding_info` method in `EpicsKafkaForwarderControl`