### PR TITLE
LoKI: Move Command Line to Bottom

### DIFF
--- a/nicos_ess/loki/guiconfig.py
+++ b/nicos_ess/loki/guiconfig.py
@@ -26,10 +26,6 @@ main_window = docked(
             "Instrument interaction",
             hsplit(
                 vbox(
-                    panel(
-                        "nicos_ess.gui.panels.cmdbuilder.CommandPanel",
-                        modules=["nicos.clients.gui.cmdlets"],
-                    ),
                     tabbed(
                         (
                             "Output",
@@ -50,6 +46,10 @@ main_window = docked(
                                 eta=True,
                             ),
                         ),
+                    ),
+                    panel(
+                        "nicos_ess.gui.panels.cmdbuilder.CommandPanel",
+                        modules=["nicos.clients.gui.cmdlets"],
                     ),
                 ),  # vsplit
                 panel(


### PR DESCRIPTION
This PR moves the command line to the bottom in the instrument interaction tab of the UI in accordance with the instrument scientists.