### PR TITLE
LoKI: Remove Instrument Set-Up (Aperture and Offset) from Samples Tab

### DIFF
--- a/nicos_ess/loki/gui/sampleconf.py
+++ b/nicos_ess/loki/gui/sampleconf.py
@@ -20,6 +20,7 @@
 # Module authors:
 #   Georg Brandl <g.brandl@fz-juelich.de>
 #   Artem Feoktystov <a.feoktystov@fz-juelich.de>
+#   AÜC Hardal <umit.hardal@ess.eu>
 #
 # *****************************************************************************
 

--- a/nicos_ess/loki/gui/sampleconf.py
+++ b/nicos_ess/loki/gui/sampleconf.py
@@ -40,19 +40,14 @@ from nicos.guisupport.utils import DoubleValidator
 from nicos.utils import findResource
 
 
-SAMPLE_KEYS = ('aperture', 'position', 'thickness', 'detoffset', 'comment')
+SAMPLE_KEYS = ('position', 'thickness', 'comment')
 
 
 def configToFrame(frame, config):
     frame.nameBox.setText(config['name'])
     frame.commentBox.setText(config['comment'])
-    frame.offsetBox.setText(str(config['detoffset']))
     frame.thickBox.setText(str(config['thickness']))
     frame.posTbl.setRowCount(len(config['position']))
-    frame.apXBox.setText(str(config['aperture'][0]))
-    frame.apYBox.setText(str(config['aperture'][1]))
-    frame.apWBox.setText(str(config['aperture'][2]))
-    frame.apHBox.setText(str(config['aperture'][3]))
     for i, (dev_name, position) in enumerate(config['position'].items()):
         frame.posTbl.setItem(i, 0, QTableWidgetItem(dev_name))
         frame.posTbl.setItem(i, 1, QTableWidgetItem(str(position)))
@@ -69,12 +64,7 @@ def configFromFrame(frame):
     return {
         'name': frame.nameBox.text(),
         'comment': frame.commentBox.text(),
-        'detoffset': float(frame.offsetBox.text()),
         'thickness': float(frame.thickBox.text()),
-        'aperture': (float(frame.apXBox.text()),
-                     float(frame.apYBox.text()),
-                     float(frame.apWBox.text()),
-                     float(frame.apHBox.text())),
         'position': position,
     }
 
@@ -109,15 +99,7 @@ class ConfigEditDialog(QDialog):
         layout.addWidget(self.frm)
         layout.addWidget(box)
         self.setLayout(layout)
-        for box in [self.frm.offsetBox, self.frm.thickBox, self.frm.apXBox,
-                    self.frm.apYBox, self.frm.apWBox, self.frm.apHBox]:
-            box.setValidator(DoubleValidator(self))
-        # List of properties that are going to be enabled in-place for edit,
-        # thus should not be visible here.
-        relevant_list = [self.frm.offsetBox, self.frm.apXBox, self.frm.apYBox,
-                         self.frm.apWBox, self.frm.apHBox]
-        for box in relevant_list:
-            box.setVisible(False)
+        self.frm.thickBox.setValidator(DoubleValidator(self))
         if config is not None:
             configToFrame(self.frm, config)
 
@@ -143,12 +125,7 @@ class ConfigEditDialog(QDialog):
             QMessageBox.warning(self, 'Error', 'Thickness cannot be zero.')
             self.frm.thickBox.setFocus()
             return
-        for box in [self.frm.offsetBox, self.frm.thickBox, self.frm.apXBox,
-                    self.frm.apYBox, self.frm.apWBox, self.frm.apHBox]:
-            if not box.text():
-                QMessageBox.warning(self, 'Error', 'Please enter valid values '
-                                                   'for all input fields.')
-                return
+
         for i in range(self.frm.posTbl.rowCount()):
             dev_name = self.frm.posTbl.item(i, 0).text()
             dev_pos = self.frm.posTbl.item(i, 1).text()
@@ -260,21 +237,6 @@ class LokiSamplePanel(Panel):
         self.sample_frame.hide()
 
         self.sample_frame.posTbl.setEnabled(False)
-        self.experiment_inputs = [self.sample_frame.offsetBox, 
-                                  self.sample_frame.apXBox, 
-                                  self.sample_frame.apYBox, 
-                                  self.sample_frame.apWBox,
-                                  self.sample_frame.apHBox]
-
-        for box in self.sample_frame.findChildren(QLineEdit):
-            if box not in self.experiment_inputs:
-                box.setEnabled(False)
-
-        self.sample_frame.offsetBox.textChanged.connect(self.set_offset)
-        self.sample_frame.apXBox.textChanged.connect(self.set_pos_x)
-        self.sample_frame.apYBox.textChanged.connect(self.set_pos_y)
-        self.sample_frame.apWBox.textChanged.connect(self.set_width)
-        self.sample_frame.apHBox.textChanged.connect(self.set_height)
 
         menu = QMenu(self)
         menu.addAction(self.actionEmpty)
@@ -475,10 +437,6 @@ class LokiSamplePanel(Panel):
 
     @pyqtSlot()
     def on_applyBtn_clicked(self):
-        if not all(map(lambda box: box.text(), self.experiment_inputs)):
-            self.showInfo('Enter valid values for all instrument configuration fields')
-            return
-
         script = self._generate_script()
         self.client.run(script)
         self.showInfo('Sample info has been transferred to the daemon.')
@@ -510,41 +468,6 @@ class LokiSamplePanel(Panel):
             self.sample_frame.show()
         index = self.list.row(item)
         configToFrame(self.sample_frame, self.configs[index])
-        # Re-validate the values
-        for box in self.experiment_inputs:
-            box.setValidator(DoubleValidator(self))
-
-    def set_offset(self, value):
-        if not value:
-            return
-        # Offset is the same for all configs
-        value = float(value)
-        for config in self.configs:
-            config['detoffset'] = value
-        self.applyBtn.setEnabled(True)
-
-    def set_pos_x(self, value):
-        self._set_aperture_value(0, value)
-
-    def set_pos_y(self, value):
-        self._set_aperture_value(1, value)
-
-    def set_width(self, value):
-        self._set_aperture_value(2, value)
-
-    def set_height(self, value):
-        self._set_aperture_value(3, value)
-
-    def _set_aperture_value(self, index, value):
-        # Aperture values are the same for all configs
-        if not value:
-            return
-        value = float(value)
-        new_values = list(self.configs[0]['aperture'])
-        new_values[index] = value
-        for config in self.configs:
-            config['aperture'] = tuple(new_values)
-        self.applyBtn.setEnabled(True)
 
     def on_list_itemDoubleClicked(self):
         self.on_editBtn_clicked()

--- a/nicos_ess/loki/gui/ui_files/sampleconf_one.ui
+++ b/nicos_ess/loki/gui/ui_files/sampleconf_one.ui
@@ -100,24 +100,7 @@
       <widget class="QLineEdit" name="commentBox"/>
      </item>
      <item row="6" column="0">
-      <layout class="QVBoxLayout" name="verticalLayout_3">
-       <item>
-        <spacer name="verticalSpacer_2">
-         <property name="orientation">
-          <enum>Qt::Vertical</enum>
-         </property>
-         <property name="sizeType">
-          <enum>QSizePolicy::Fixed</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>20</width>
-           <height>30</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
-      </layout>
+      <layout class="QVBoxLayout" name="verticalLayout_3"/>
      </item>
      <item row="5" column="0">
       <layout class="QVBoxLayout" name="verticalLayout">
@@ -151,34 +134,7 @@
       </widget>
      </item>
      <item row="7" column="1">
-      <layout class="QHBoxLayout" name="horizontalLayout_3">
-       <item>
-        <widget class="QLineEdit" name="offsetBox">
-         <property name="maximumSize">
-          <size>
-           <width>200</width>
-           <height>16777215</height>
-          </size>
-         </property>
-         <property name="text">
-          <string>0.0</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <spacer name="horizontalSpacer_4">
-         <property name="orientation">
-          <enum>Qt::Horizontal</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>40</width>
-           <height>20</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
-      </layout>
+      <layout class="QHBoxLayout" name="horizontalLayout_3"/>
      </item>
      <item row="4" column="0" colspan="2">
       <widget class="Line" name="line_3">
@@ -241,131 +197,6 @@
        </property>
       </widget>
      </item>
-     <item row="6" column="1">
-      <layout class="QGridLayout" name="gridLayout_2">
-       <item row="0" column="0">
-        <widget class="QLineEdit" name="apXBox">
-         <property name="minimumSize">
-          <size>
-           <width>50</width>
-           <height>0</height>
-          </size>
-         </property>
-         <property name="maximumSize">
-          <size>
-           <width>100</width>
-           <height>16777215</height>
-          </size>
-         </property>
-         <property name="text">
-          <string>0.0</string>
-         </property>
-        </widget>
-       </item>
-       <item row="0" column="2">
-        <widget class="QLineEdit" name="apYBox">
-         <property name="minimumSize">
-          <size>
-           <width>50</width>
-           <height>0</height>
-          </size>
-         </property>
-         <property name="maximumSize">
-          <size>
-           <width>100</width>
-           <height>16777215</height>
-          </size>
-         </property>
-         <property name="text">
-          <string>0.0</string>
-         </property>
-        </widget>
-       </item>
-       <item row="1" column="0">
-        <widget class="QLineEdit" name="apWBox">
-         <property name="minimumSize">
-          <size>
-           <width>50</width>
-           <height>0</height>
-          </size>
-         </property>
-         <property name="maximumSize">
-          <size>
-           <width>100</width>
-           <height>16777215</height>
-          </size>
-         </property>
-         <property name="text">
-          <string>20.0</string>
-         </property>
-        </widget>
-       </item>
-       <item row="1" column="2">
-        <widget class="QLineEdit" name="apHBox">
-         <property name="minimumSize">
-          <size>
-           <width>50</width>
-           <height>0</height>
-          </size>
-         </property>
-         <property name="maximumSize">
-          <size>
-           <width>100</width>
-           <height>16777215</height>
-          </size>
-         </property>
-         <property name="text">
-          <string>20.0</string>
-         </property>
-        </widget>
-       </item>
-       <item row="0" column="1">
-        <spacer name="horizontalSpacer">
-         <property name="orientation">
-          <enum>Qt::Horizontal</enum>
-         </property>
-         <property name="sizeType">
-          <enum>QSizePolicy::Fixed</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>10</width>
-           <height>20</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
-       <item row="1" column="3" colspan="2">
-        <spacer name="horizontalSpacer_2">
-         <property name="orientation">
-          <enum>Qt::Horizontal</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>40</width>
-           <height>20</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
-       <item row="0" column="3">
-        <spacer name="horizontalSpacer_3">
-         <property name="orientation">
-          <enum>Qt::Horizontal</enum>
-         </property>
-         <property name="sizeType">
-          <enum>QSizePolicy::Fixed</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>10</width>
-           <height>20</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
-      </layout>
-     </item>
     </layout>
    </item>
   </layout>
@@ -378,11 +209,6 @@
   <tabstop>addDevBtn</tabstop>
   <tabstop>delDevBtn</tabstop>
   <tabstop>readDevsBtn</tabstop>
-  <tabstop>apXBox</tabstop>
-  <tabstop>apYBox</tabstop>
-  <tabstop>apWBox</tabstop>
-  <tabstop>apHBox</tabstop>
-  <tabstop>offsetBox</tabstop>
  </tabstops>
  <resources/>
  <connections/>

--- a/nicos_ess/loki/gui/ui_files/sampleconf_summary.ui
+++ b/nicos_ess/loki/gui/ui_files/sampleconf_summary.ui
@@ -28,21 +28,25 @@
    </property>
    <item>
     <layout class="QGridLayout" name="gridLayout">
-     <item row="2" column="1">
-      <widget class="QLineEdit" name="commentBox"/>
-     </item>
-     <item row="7" column="0">
-      <widget class="QLabel" name="whatLbl_2">
-       <property name="font">
-        <font>
-         <weight>75</weight>
-         <bold>true</bold>
-        </font>
-       </property>
+     <item row="2" column="0">
+      <widget class="QLabel" name="label_6">
        <property name="text">
-        <string>Instrument Configuration</string>
+        <string>Comment:</string>
        </property>
       </widget>
+     </item>
+     <item row="1" column="1">
+      <widget class="QLineEdit" name="nameBox"/>
+     </item>
+     <item row="3" column="0">
+      <widget class="QLabel" name="label_7">
+       <property name="text">
+        <string>Thickness:</string>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="1">
+      <widget class="QLineEdit" name="commentBox"/>
      </item>
      <item row="5" column="0">
       <layout class="QVBoxLayout" name="verticalLayout">
@@ -67,45 +71,6 @@
         </spacer>
        </item>
       </layout>
-     </item>
-     <item row="5" column="1">
-      <layout class="QVBoxLayout" name="verticalLayout_2">
-       <item>
-        <widget class="QTableWidget" name="posTbl">
-         <column>
-          <property name="text">
-           <string>Device</string>
-          </property>
-         </column>
-         <column>
-          <property name="text">
-           <string>Position</string>
-          </property>
-         </column>
-        </widget>
-       </item>
-      </layout>
-     </item>
-     <item row="2" column="0">
-      <widget class="QLabel" name="label_6">
-       <property name="text">
-        <string>Comment:</string>
-       </property>
-      </widget>
-     </item>
-     <item row="1" column="0">
-      <widget class="QLabel" name="label_2">
-       <property name="text">
-        <string>Sample name:</string>
-       </property>
-      </widget>
-     </item>
-     <item row="10" column="0">
-      <widget class="QLabel" name="label_4">
-       <property name="text">
-        <string>Detector offset:</string>
-       </property>
-      </widget>
      </item>
      <item row="3" column="1">
       <layout class="QHBoxLayout" name="horizontalLayout_4">
@@ -144,12 +109,26 @@
        </item>
       </layout>
      </item>
-     <item row="9" column="0" colspan="2">
-      <widget class="Line" name="line">
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-      </widget>
+     <item row="5" column="1">
+      <layout class="QVBoxLayout" name="verticalLayout_2">
+       <item>
+        <widget class="QTableWidget" name="posTbl">
+         <column>
+          <property name="text">
+           <string>Device</string>
+          </property>
+         </column>
+         <column>
+          <property name="text">
+           <string>Position</string>
+          </property>
+         </column>
+        </widget>
+       </item>
+      </layout>
+     </item>
+     <item row="6" column="1">
+      <layout class="QHBoxLayout" name="horizontalLayout_3"/>
      </item>
      <item row="4" column="0" colspan="2">
       <widget class="Line" name="line_3">
@@ -157,233 +136,6 @@
         <enum>Qt::Horizontal</enum>
        </property>
       </widget>
-     </item>
-     <item row="8" column="0">
-      <layout class="QVBoxLayout" name="verticalLayout_3">
-       <item>
-        <widget class="QLabel" name="label_11">
-         <property name="text">
-          <string>Aperture:</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <spacer name="verticalSpacer_2">
-         <property name="orientation">
-          <enum>Qt::Vertical</enum>
-         </property>
-         <property name="sizeType">
-          <enum>QSizePolicy::Fixed</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>20</width>
-           <height>30</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
-      </layout>
-     </item>
-     <item row="1" column="1">
-      <widget class="QLineEdit" name="nameBox"/>
-     </item>
-     <item row="8" column="1">
-      <layout class="QGridLayout" name="gridLayout_2">
-       <item row="0" column="0">
-        <widget class="QLabel" name="label_12">
-         <property name="text">
-          <string>Pos X:</string>
-         </property>
-        </widget>
-       </item>
-       <item row="0" column="1">
-        <widget class="QLineEdit" name="apXBox">
-         <property name="minimumSize">
-          <size>
-           <width>50</width>
-           <height>0</height>
-          </size>
-         </property>
-         <property name="maximumSize">
-          <size>
-           <width>100</width>
-           <height>16777215</height>
-          </size>
-         </property>
-         <property name="text">
-          <string>0.0</string>
-         </property>
-        </widget>
-       </item>
-       <item row="0" column="3">
-        <widget class="QLabel" name="label_13">
-         <property name="text">
-          <string>Pos Y:</string>
-         </property>
-        </widget>
-       </item>
-       <item row="0" column="4">
-        <widget class="QLineEdit" name="apYBox">
-         <property name="minimumSize">
-          <size>
-           <width>50</width>
-           <height>0</height>
-          </size>
-         </property>
-         <property name="maximumSize">
-          <size>
-           <width>100</width>
-           <height>16777215</height>
-          </size>
-         </property>
-         <property name="text">
-          <string>0.0</string>
-         </property>
-        </widget>
-       </item>
-       <item row="1" column="0">
-        <widget class="QLabel" name="label_14">
-         <property name="text">
-          <string>Width:</string>
-         </property>
-        </widget>
-       </item>
-       <item row="1" column="1">
-        <widget class="QLineEdit" name="apWBox">
-         <property name="minimumSize">
-          <size>
-           <width>50</width>
-           <height>0</height>
-          </size>
-         </property>
-         <property name="maximumSize">
-          <size>
-           <width>100</width>
-           <height>16777215</height>
-          </size>
-         </property>
-         <property name="text">
-          <string>20.0</string>
-         </property>
-        </widget>
-       </item>
-       <item row="1" column="3">
-        <widget class="QLabel" name="label_15">
-         <property name="text">
-          <string>Height:</string>
-         </property>
-        </widget>
-       </item>
-       <item row="1" column="4">
-        <widget class="QLineEdit" name="apHBox">
-         <property name="minimumSize">
-          <size>
-           <width>50</width>
-           <height>0</height>
-          </size>
-         </property>
-         <property name="maximumSize">
-          <size>
-           <width>100</width>
-           <height>16777215</height>
-          </size>
-         </property>
-         <property name="text">
-          <string>20.0</string>
-         </property>
-        </widget>
-       </item>
-       <item row="0" column="2">
-        <spacer name="horizontalSpacer">
-         <property name="orientation">
-          <enum>Qt::Horizontal</enum>
-         </property>
-         <property name="sizeType">
-          <enum>QSizePolicy::Fixed</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>10</width>
-           <height>20</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
-       <item row="0" column="5">
-        <spacer name="horizontalSpacer_3">
-         <property name="orientation">
-          <enum>Qt::Horizontal</enum>
-         </property>
-         <property name="sizeType">
-          <enum>QSizePolicy::Fixed</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>10</width>
-           <height>20</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
-       <item row="1" column="5" colspan="2">
-        <spacer name="horizontalSpacer_2">
-         <property name="orientation">
-          <enum>Qt::Horizontal</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>40</width>
-           <height>20</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
-      </layout>
-     </item>
-     <item row="6" column="0" colspan="2">
-      <widget class="Line" name="line_2">
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-      </widget>
-     </item>
-     <item row="10" column="1">
-      <layout class="QHBoxLayout" name="horizontalLayout_3">
-       <item>
-        <widget class="QLineEdit" name="offsetBox">
-         <property name="maximumSize">
-          <size>
-           <width>200</width>
-           <height>16777215</height>
-          </size>
-         </property>
-         <property name="text">
-          <string>0.0</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QLabel" name="label_10">
-         <property name="text">
-          <string>mm</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <spacer name="horizontalSpacer_4">
-         <property name="orientation">
-          <enum>Qt::Horizontal</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>40</width>
-           <height>20</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
-      </layout>
      </item>
      <item row="0" column="0" colspan="2">
       <widget class="QLabel" name="whatLbl">
@@ -398,10 +150,10 @@
        </property>
       </widget>
      </item>
-     <item row="3" column="0">
-      <widget class="QLabel" name="label_7">
+     <item row="1" column="0">
+      <widget class="QLabel" name="label_2">
        <property name="text">
-        <string>Thickness:</string>
+        <string>Sample name:</string>
        </property>
       </widget>
      </item>
@@ -413,11 +165,6 @@
   <tabstop>nameBox</tabstop>
   <tabstop>commentBox</tabstop>
   <tabstop>posTbl</tabstop>
-  <tabstop>apXBox</tabstop>
-  <tabstop>apYBox</tabstop>
-  <tabstop>apWBox</tabstop>
-  <tabstop>apHBox</tabstop>
-  <tabstop>offsetBox</tabstop>
   <tabstop>thickBox</tabstop>
  </tabstops>
  <resources/>


### PR DESCRIPTION
This PR removes the instrument configuration concerning aperture and detector offset from the Samples tab of the LoKI GUI. These setting will be moved to a new tab in accordance of the wishes of the instrument scientists. 