### PR TITLE
Fix a small bug formed during refactoring experiment config to a new tab

### DIFF
--- a/nicos_ess/loki/gui/sampleconf.py
+++ b/nicos_ess/loki/gui/sampleconf.py
@@ -238,6 +238,9 @@ class LokiSamplePanel(Panel):
 
         self.sample_frame.posTbl.setEnabled(False)
 
+        for box in self.sample_frame.findChildren(QLineEdit):
+            box.setEnabled(False)
+
         menu = QMenu(self)
         menu.addAction(self.actionEmpty)
         menu.addAction(self.actionGenerate)


### PR DESCRIPTION
This PR fixes a small bug in sample configuration (basically sample configuration panel should be disabled on the frame, one must click edit to edit). The bug formed because I mistakenly deleted that line during refactoring the experiment configuration to a new tab.