### PR TITLE
Update to latest PyQt5 and see what happens

### DIFF
--- a/nicos_ess/requirements.txt
+++ b/nicos_ess/requirements.txt
@@ -8,8 +8,8 @@ kafka-logging-handler<=0.2.4
 kafka-python>=1.4.6
 p4p
 pyepics
-PyQt5==5.14.2
-PyQt5-sip==12.8
-PyQtWebEngine==5.14.0
 h5py>=2.6
+PyQt5
+PyQtWebEngine
+QScintilla
 https://github.com/ess-dmsc/yuos_query/archive/v0.1.9.tar.gz

--- a/nicos_ess/requirements.txt
+++ b/nicos_ess/requirements.txt
@@ -8,7 +8,6 @@ kafka-logging-handler<=0.2.4
 kafka-python>=1.4.6
 p4p
 pyepics
-h5py>=2.6
 PyQt5==5.15.4
 PyQtWebEngine==5.15.4
 QScintilla==2.12.1

--- a/nicos_ess/requirements.txt
+++ b/nicos_ess/requirements.txt
@@ -9,7 +9,7 @@ kafka-python>=1.4.6
 p4p
 pyepics
 h5py>=2.6
-PyQt5
-PyQtWebEngine
-QScintilla
+PyQt5==5.15.4
+PyQtWebEngine==5.15.4
+QScintilla==2.12.1
 https://github.com/ess-dmsc/yuos_query/archive/v0.1.9.tar.gz


### PR DESCRIPTION
About a year ago I tried updating to 5.15.0 and found some of the buttons didn't behave properly.
There have been a number of updates since then so I think we should give it another go.

I've tried it on a mac and it is fine, but @ebadkamil can you try it on Linux please?

Let me know in the comments if anything isn't working and which version number got installed.
`pip install -r nicos_ess/requirements.txt --upgrade `

I'll log on to one of the client machines at YMIR and try it there too (pinging @kmurica so he is aware of that).

If all goes well then I'll push it through Gerrit.
