### PR TITLE
Create row above and button work when no rows exist

### DIFF
--- a/nicos_ess/loki/gui/loki_scriptbuilder.py
+++ b/nicos_ess/loki/gui/loki_scriptbuilder.py
@@ -245,14 +245,18 @@ class LokiScriptBuilderPanel(LokiPanelBase):
         self.tableView.model().removeRows(rows_to_remove)
 
     def _insert_row_above(self):
-        lowest, highest = self._get_selected_rows_limits()
+        lowest, _ = self._get_selected_rows_limits()
         if lowest is not None:
             self.tableView.model().insertRow(lowest)
+        elif self.model.num_rows == 0:
+           self.tableView.model().insertRow(0)
 
     def _insert_row_below(self):
         _, highest = self._get_selected_rows_limits()
         if highest is not None:
             self.tableView.model().insertRow(highest + 1)
+        elif self.model.num_rows == 0:
+           self.tableView.model().insertRow(0)
 
     def _get_selected_rows_limits(self):
         lowest = None

--- a/nicos_ess/loki/gui/loki_scriptbuilder_model.py
+++ b/nicos_ess/loki/gui/loki_scriptbuilder_model.py
@@ -126,3 +126,7 @@ class LokiScriptModel(QAbstractTableModel):
 
     def empty_table(self, rows, columns):
         return [[""] * columns for _ in range(rows)]
+
+    @property
+    def num_rows(self):
+        return len(self._table_data)


### PR DESCRIPTION
When no rows exist in a table insert row above and below creates an empty row.