### PR TITLE
Make loki script settings resize correctly

### DIFF
--- a/nicos_ess/loki/gui/ui_files/loki_scriptbuilder.ui
+++ b/nicos_ess/loki/gui/ui_files/loki_scriptbuilder.ui
@@ -26,6 +26,9 @@
       <string>Settings</string>
      </property>
      <layout class="QGridLayout" name="gridLayout">
+      <property name="sizeConstraint">
+       <enum>QLayout::SetMinAndMaxSize</enum>
+      </property>
       <item row="0" column="1" colspan="2">
        <widget class="QComboBox" name="comboTransOrder">
         <property name="minimumSize">


### PR DESCRIPTION
Stops the setting panels on the left collapsing