### PR TITLE
LoKI: Fix things in script builder codes

### DIFF
--- a/nicos_ess/loki/gui/loki_scriptbuilder.py
+++ b/nicos_ess/loki/gui/loki_scriptbuilder.py
@@ -33,7 +33,6 @@ class LokiScriptBuilderPanel(LokiPanelBase):
                )
 
         self.window = parent
-
         self.duration_options = ['Mevents', 'seconds', 'frames']
 
         self.permanent_columns = {
@@ -62,7 +61,8 @@ class LokiScriptBuilderPanel(LokiPanelBase):
             self.permanent_columns[name]
             if name in self.permanent_columns
             else self.optional_columns[name][0]
-            for name in self.columns_in_order]
+            for name in self.columns_in_order
+        ]
 
         self.model = LokiScriptModel(headers)
         self.tableView.setModel(self.model)
@@ -153,11 +153,11 @@ class LokiScriptBuilderPanel(LokiPanelBase):
 
     def _fill_table(self, headers, data):
         # corresponding indices of elements in headers_from_file list to headers
-        indices = [i for i, e in enumerate(self.columns_in_order)
-                   if e in headers]
+        indices = [index for index, element in
+                   enumerate(self.columns_in_order) if element in headers]
 
         table_data = []
-        for idx, row in enumerate(data):
+        for index, row in enumerate(data):
             # create appropriate length list to fill the table row
             row = self._fill_elements(row, indices, len(self.columns_in_order))
             table_data.append(row)
@@ -193,6 +193,7 @@ class LokiScriptBuilderPanel(LokiPanelBase):
 
         if not filename:
             return
+        # TODO: This is not general enough.
         if not filename.endswith(('.txt', '.csv')):
             filename = filename + '.csv'
 
@@ -205,8 +206,9 @@ class LokiScriptBuilderPanel(LokiPanelBase):
             self.showError(f'Cannot write table contents to {filename}:\n{ex}')
 
     def is_data_in_hidden_columns(self):
-        optional_indices = [i for i, e in enumerate(self.columns_in_order)
-                            if e in self.optional_columns.keys()]
+        optional_indices = [index for index, element in
+                            enumerate(self.columns_in_order)
+                            if element in self.optional_columns.keys()]
         # Transform table_data to allow easy access to columns like data[0]
         data = list(zip(*self.model.table_data))
         return any(

--- a/nicos_ess/loki/gui/loki_scriptbuilder.py
+++ b/nicos_ess/loki/gui/loki_scriptbuilder.py
@@ -192,8 +192,7 @@ class LokiScriptBuilderPanel(LokiPanelBase):
 
         self.model.table_data = table_data
 
-    @staticmethod
-    def _fill_elements(row, indices, length):
+    def _fill_elements(self, row, indices, length):
         """Returns a list with row elements placed in the given indices.
         """
         if len(row) == length:

--- a/nicos_ess/loki/gui/loki_scriptbuilder.py
+++ b/nicos_ess/loki/gui/loki_scriptbuilder.py
@@ -164,7 +164,8 @@ class LokiScriptBuilderPanel(LokiPanelBase):
 
         self.model.table_data = table_data
 
-    def _fill_elements(self, row, indices, length):
+    @staticmethod
+    def _fill_elements(row, indices, length):
         """Returns a list with row elements placed in the given indices.
         """
         if len(row) == length:

--- a/nicos_ess/loki/gui/loki_scriptbuilder.py
+++ b/nicos_ess/loki/gui/loki_scriptbuilder.py
@@ -21,7 +21,7 @@ class LokiScriptBuilderPanel(LokiPanelBase):
     _available_trans_options = OrderedDict({
         'All TRANS First': TransOrder.TRANSFIRST,
         'All SANS First': TransOrder.SANSFIRST,
-        'TRANS then SANS':TransOrder.TRANSTHENSANS,
+        'TRANS then SANS': TransOrder.TRANSTHENSANS,
         'SANS then TRANS': TransOrder.SANSTHENTRANS,
         'Simultaneous': TransOrder.SIMULTANEOUS
     })
@@ -130,8 +130,8 @@ class LokiScriptBuilderPanel(LokiPanelBase):
         filename = QFileDialog.getOpenFileName(
             self,
             'Open table',
-            osp.expanduser('~') if self.last_save_location is None \
-                else self.last_save_location,
+            osp.expanduser('~') if self.last_save_location is None
+            else self.last_save_location,
             'Table Files (*.txt *.csv)')[0]
 
         if not filename:
@@ -148,7 +148,7 @@ class LokiScriptBuilderPanel(LokiPanelBase):
         self._fill_table(headers_from_file, data)
 
         for optional in set(headers_from_file).intersection(
-            set(self.optional_columns.keys())):
+                set(self.optional_columns.keys())):
             self.optional_columns[optional][1].setChecked(True)
 
     def _fill_table(self, headers, data):
@@ -185,8 +185,8 @@ class LokiScriptBuilderPanel(LokiPanelBase):
         filename = QFileDialog.getSaveFileName(
             self,
             'Save table',
-            osp.expanduser('~') if self.last_save_location is None \
-                else self.last_save_location,
+            osp.expanduser('~') if self.last_save_location is None
+            else self.last_save_location,
             'Table files (*.txt *.csv)',
             initialFilter='*.txt;;*.csv')[0]
 
@@ -249,14 +249,14 @@ class LokiScriptBuilderPanel(LokiPanelBase):
         if lowest is not None:
             self.tableView.model().insertRow(lowest)
         elif self.model.num_rows == 0:
-           self.tableView.model().insertRow(0)
+            self.tableView.model().insertRow(0)
 
     def _insert_row_below(self):
         _, highest = self._get_selected_rows_limits()
         if highest is not None:
             self.tableView.model().insertRow(highest + 1)
         elif self.model.num_rows == 0:
-           self.tableView.model().insertRow(0)
+            self.tableView.model().insertRow(0)
 
     def _get_selected_rows_limits(self):
         lowest = None
@@ -362,20 +362,22 @@ class LokiScriptBuilderPanel(LokiPanelBase):
     def on_generateScriptButton_clicked(self):
         labeled_data = self._extract_labeled_data()
 
-        if self._available_trans_options[self.comboTransOrder.currentText()] ==\
-            TransOrder.SIMULTANEOUS:
-                if not all([data['sans_duration'] == data['trans_duration']
-                            for data in labeled_data]):
-                    self.showError(
+        if self._available_trans_options[self.comboTransOrder.currentText()]\
+                == TransOrder.SIMULTANEOUS:
+            if not all([data['sans_duration'] == data['trans_duration']
+                        for data in labeled_data]):
+                self.showError(
                         'Different SANS and TRANS duration specified in '
                         'SIMULTANEOUS mode. SANS duration will be used in '
-                        'the script.')
+                        'the script.'
+                )
 
-        _trans_order = self._available_trans_options[self.comboTransOrder.currentText()]
-        template = ScriptGenerator.from_trans_order(_trans_order).generate_script(
-            labeled_data,
-            self.comboTransDurationType.currentText(),
-            self.comboSansDurationType.currentText())
+        _trans_order = self._available_trans_options[
+            self.comboTransOrder.currentText()]
+        template = ScriptGenerator.from_trans_order(_trans_order).\
+            generate_script(labeled_data,
+                            self.comboTransDurationType.currentText(),
+                            self.comboSansDurationType.currentText())
 
         self.mainwindow.codeGenerated.emit(template)
 
@@ -396,7 +398,8 @@ class LokiScriptBuilderPanel(LokiPanelBase):
     def _on_duration_type_changed(self, column_name, value):
         column_number = self.columns_in_order.index(column_name)
         self._set_column_title(column_number,
-            f'{self.permanent_columns[column_name]}\n({value})')
+                               f'{self.permanent_columns[column_name]}'
+                               f'\n({value})')
 
     def _set_column_title(self, index, title):
         self.model.setHeaderData(index, Qt.Horizontal, title)

--- a/nicos_ess/loki/gui/loki_scriptbuilder.py
+++ b/nicos_ess/loki/gui/loki_scriptbuilder.py
@@ -185,7 +185,7 @@ class LokiScriptBuilderPanel(LokiPanelBase):
                    enumerate(self.columns_in_order) if element in headers]
 
         table_data = []
-        for index, row in enumerate(data):
+        for row in data:
             # create appropriate length list to fill the table row
             row = self._fill_elements(row, indices, len(self.columns_in_order))
             table_data.append(row)

--- a/nicos_ess/loki/gui/loki_scriptbuilder.py
+++ b/nicos_ess/loki/gui/loki_scriptbuilder.py
@@ -24,7 +24,7 @@
 #
 # *****************************************************************************
 
-"""LoKI Experiment Configuration dialog."""
+"""LoKI Script Builder Panel."""
 
 import os.path as osp
 from collections import OrderedDict

--- a/nicos_ess/loki/gui/loki_scriptbuilder.py
+++ b/nicos_ess/loki/gui/loki_scriptbuilder.py
@@ -1,3 +1,31 @@
+#  -*- coding: utf-8 -*-
+# *****************************************************************************
+# NICOS, the Networked Instrument Control System of the MLZ
+# Copyright (c) 2009-2021 by the NICOS contributors (see AUTHORS)
+#
+# This program is free software; you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software
+# Foundation; either version 2 of the License, or (at your option) any later
+# version.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc.,
+# 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#
+# Module authors:
+#
+#   Ebad Kamil <Ebad.Kamil@ess.eu>
+#   Matt Clarke <matt.clarke@ess.eu>
+#
+# *****************************************************************************
+
+"""LoKI Experiment Configuration dialog."""
+
 import os.path as osp
 from collections import OrderedDict
 from functools import partial
@@ -193,7 +221,6 @@ class LokiScriptBuilderPanel(LokiPanelBase):
 
         if not filename:
             return
-        # TODO: This is not general enough.
         if not filename.endswith(('.txt', '.csv')):
             filename = filename + '.csv'
 

--- a/nicos_ess/loki/gui/loki_scriptbuilder_model.py
+++ b/nicos_ess/loki/gui/loki_scriptbuilder_model.py
@@ -153,7 +153,8 @@ class LokiScriptModel(QAbstractTableModel):
         self.table_data = self.empty_table(
             len(self._table_data), len(self._header_data))
 
-    def empty_table(self, rows, columns):
+    @staticmethod
+    def empty_table(rows, columns):
         return [[""] * columns for _ in range(rows)]
 
     @property

--- a/nicos_ess/loki/gui/loki_scriptbuilder_model.py
+++ b/nicos_ess/loki/gui/loki_scriptbuilder_model.py
@@ -153,8 +153,7 @@ class LokiScriptModel(QAbstractTableModel):
         self.table_data = self.empty_table(
             len(self._table_data), len(self._header_data))
 
-    @staticmethod
-    def empty_table(rows, columns):
+    def empty_table(self, rows, columns):
         return [[""] * columns for _ in range(rows)]
 
     @property

--- a/nicos_ess/loki/gui/loki_scriptbuilder_model.py
+++ b/nicos_ess/loki/gui/loki_scriptbuilder_model.py
@@ -1,3 +1,30 @@
+#  -*- coding: utf-8 -*-
+# *****************************************************************************
+# NICOS, the Networked Instrument Control System of the MLZ
+# Copyright (c) 2009-2021 by the NICOS contributors (see AUTHORS)
+#
+# This program is free software; you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software
+# Foundation; either version 2 of the License, or (at your option) any later
+# version.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc.,
+# 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#
+# Module authors:
+#
+#   Matt Clarke <matt.clarke@ess.eu>
+#
+# *****************************************************************************
+
+"""LoKI Script Model."""
+
 from nicos.guisupport.qt import QAbstractTableModel, QModelIndex, Qt
 
 

--- a/nicos_ess/loki/gui/loki_scriptbuilder_model.py
+++ b/nicos_ess/loki/gui/loki_scriptbuilder_model.py
@@ -44,7 +44,8 @@ class LokiScriptModel(QAbstractTableModel):
     def table_data(self, new_data):
         if not self._is_data_dimension_valid(new_data):
             raise AttributeError(
-                f"Attribute must be a 2D list of shape (_, {len(self._header_data)})"
+                f"Attribute must be a 2D list of shape"
+                f" (_, {len(self._header_data)})"
             )
 
         # Extend the list with empty rows if value has less than n_rows
@@ -112,7 +113,7 @@ class LokiScriptModel(QAbstractTableModel):
         return True
 
     def update_data_from_clipboard(
-        self, copied_data, top_left_index, hidden_columns=None):
+            self, copied_data, top_left_index, hidden_columns=None):
         # Copied data is tabular so insert at top-left most position
         for row_index, row_data in enumerate(copied_data):
             col_index = 0
@@ -124,7 +125,8 @@ class LokiScriptModel(QAbstractTableModel):
                     if current_row >= len(self._table_data):
                         self.create_empty_row(current_row)
 
-                    if hidden_columns is not None and current_column in hidden_columns:
+                    if hidden_columns is not None \
+                            and current_column in hidden_columns:
                         continue
                     self._table_data[current_row][current_column] = value
 

--- a/nicos_ess/loki/gui/script_generator.py
+++ b/nicos_ess/loki/gui/script_generator.py
@@ -76,8 +76,7 @@ def _do_simultaneous(row_values, sans_duration_type):
 
 
 class TransFirst:
-    @staticmethod
-    def generate_script(labeled_data, trans_duration_type,
+    def generate_script(self, labeled_data, trans_duration_type,
                         sans_duration_type):
         template = ""
         for row_values in labeled_data:
@@ -91,8 +90,7 @@ class TransFirst:
 
 
 class SansFirst:
-    @staticmethod
-    def generate_script(labeled_data, trans_duration_type,
+    def generate_script(self, labeled_data, trans_duration_type,
                         sans_duration_type):
         template = ""
         for row_values in labeled_data:
@@ -106,8 +104,7 @@ class SansFirst:
 
 
 class TransThenSans:
-    @staticmethod
-    def generate_script(labeled_data, trans_duration_type,
+    def generate_script(self, labeled_data, trans_duration_type,
                         sans_duration_type):
         template = ""
         for row_values in labeled_data:
@@ -118,8 +115,7 @@ class TransThenSans:
 
 
 class SansThenTrans:
-    @staticmethod
-    def generate_script(labeled_data, trans_duration_type,
+    def generate_script(self, labeled_data, trans_duration_type,
                         sans_duration_type):
         template = ""
         for row_values in labeled_data:
@@ -130,8 +126,7 @@ class SansThenTrans:
 
 
 class Simultaneous:
-    @staticmethod
-    def generate_script(labeled_data, sans_duration_type):
+    def generate_script(self, labeled_data, sans_duration_type):
         template = ""
         for row_values in labeled_data:
             template += _do_simultaneous(row_values, sans_duration_type)

--- a/nicos_ess/loki/gui/script_generator.py
+++ b/nicos_ess/loki/gui/script_generator.py
@@ -126,8 +126,7 @@ class SansThenTrans:
 
 
 class Simultaneous:
-    def generate_script(self, labeled_data, trans_duration_type,
-                        sans_duration_type):
+    def generate_script(self, labeled_data, sans_duration_type):
         template = ""
         for row_values in labeled_data:
             template += _do_simultaneous(row_values, sans_duration_type)

--- a/nicos_ess/loki/gui/script_generator.py
+++ b/nicos_ess/loki/gui/script_generator.py
@@ -1,3 +1,31 @@
+#  -*- coding: utf-8 -*-
+# *****************************************************************************
+# NICOS, the Networked Instrument Control System of the MLZ
+# Copyright (c) 2009-2021 by the NICOS contributors (see AUTHORS)
+#
+# This program is free software; you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software
+# Foundation; either version 2 of the License, or (at your option) any later
+# version.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc.,
+# 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#
+# Module authors:
+#
+#   Ebad Kamil <Ebad.Kamil@ess.eu>
+#   Matt Clarke <matt.clarke@ess.eu>
+#
+# *****************************************************************************
+
+"""LoKI Script Generator."""
+
 from enum import Enum
 
 

--- a/nicos_ess/loki/gui/script_generator.py
+++ b/nicos_ess/loki/gui/script_generator.py
@@ -126,7 +126,8 @@ class SansThenTrans:
 
 
 class Simultaneous:
-    def generate_script(self, labeled_data, sans_duration_type):
+    def generate_script(self, labeled_data, trans_duration_type,
+                        sans_duration_type):
         template = ""
         for row_values in labeled_data:
             template += _do_simultaneous(row_values, sans_duration_type)


### PR DESCRIPTION
This PR fix some PEP issues, adds headers and make some other corrections to the codes that handle script generation and table manipulation for LoKI.

On the side note:
@mattclarke and @ebadkamil 

If one chooses `SIMULTANEOUS` as trans order in settings in `Prototype` tab, Python throws an error concerning positional arguments (required 2 but given 3). This only happens for `SIMULTANEOUS`.