### PR TITLE
LoKI: Wire up action 'empty' with 'new' to reduce two step action to one

### DIFF
--- a/nicos_ess/loki/gui/sampleconf.py
+++ b/nicos_ess/loki/gui/sampleconf.py
@@ -274,6 +274,7 @@ class LokiSamplePanel(LokiPanelBase):
         self._clear_samples()
         self.sample_frame.hide()
         self.sampleGroup.setEnabled(True)
+        self.on_newBtn_clicked()
 
     @pyqtSlot()
     def on_actionGenerate_triggered(self):


### PR DESCRIPTION
When one clicks the `Empty` under `Create New` in `Select a sample list` in `Samples` tab, it is required to click `New` at the bottom-left as a second step. This PR removes this unnecessary step by wiring these two action up without effecting the original behaviour of the `Empty`.