### PR TITLE
LoKI: Replace if-elif-else with dict switch in script generator

### DIFF
--- a/nicos_ess/loki/gui/script_generator.py
+++ b/nicos_ess/loki/gui/script_generator.py
@@ -145,8 +145,8 @@ class ScriptGenerator:
             TransOrder.SANSTHENTRANS: SansThenTrans,
             TransOrder.SIMULTANEOUS: Simultaneous
         }
-        if trans_order in order_attributes.keys():
-            return order_attributes[trans_order]()
+        if trans_order in classes_by_trans_order:
+            return classes_by_trans_order[trans_order]()
         else:
             raise NotImplementedError(
                 f"Unspecified trans order {trans_order.name}")

--- a/nicos_ess/loki/gui/script_generator.py
+++ b/nicos_ess/loki/gui/script_generator.py
@@ -138,7 +138,7 @@ class Simultaneous:
 class ScriptGenerator:
     @classmethod
     def from_trans_order(cls, trans_order):
-        order_attributes = {
+        classes_by_trans_order = {
             TransOrder.TRANSFIRST: TransFirst,
             TransOrder.SANSFIRST: SansFirst,
             TransOrder.TRANSTHENSANS: TransThenSans,

--- a/nicos_ess/loki/gui/script_generator.py
+++ b/nicos_ess/loki/gui/script_generator.py
@@ -138,16 +138,15 @@ class Simultaneous:
 class ScriptGenerator:
     @classmethod
     def from_trans_order(cls, trans_order):
-        if trans_order == TransOrder.TRANSFIRST:
-            return TransFirst()
-        elif trans_order == TransOrder.SANSFIRST:
-            return SansFirst()
-        elif trans_order == TransOrder.TRANSTHENSANS:
-            return TransThenSans()
-        elif trans_order == TransOrder.SANSTHENTRANS:
-            return SansThenTrans()
-        elif trans_order == TransOrder.SIMULTANEOUS:
-            return Simultaneous()
+        order_attributes = {
+            TransOrder.TRANSFIRST: TransFirst,
+            TransOrder.SANSFIRST: SansFirst,
+            TransOrder.TRANSTHENSANS: TransThenSans,
+            TransOrder.SANSTHENTRANS: SansThenTrans,
+            TransOrder.SIMULTANEOUS: Simultaneous
+        }
+        if trans_order in order_attributes.keys():
+            return order_attributes[trans_order]()
         else:
             raise NotImplementedError(
                 f"Unspecified trans order {trans_order.name}")


### PR DESCRIPTION
This PR replaces `if-elif-else` chain in `ScriptGenerator` class method with a dictionary switch. The new implementation is tested as follows:

- A script is generated for all Trans options and saved along with the table that generates them.
- New method is implemented.
- Saved table loaded and each script is generated with the new implementation and saved.
- Generated scripts are then compared with Unix's built in `diff`. Scripts are identical.

