### PR TITLE
Loki-script: double click should not clear cell

### DIFF
--- a/nicos_ess/loki/gui/loki_scriptbuilder_model.py
+++ b/nicos_ess/loki/gui/loki_scriptbuilder_model.py
@@ -64,7 +64,7 @@ class LokiScriptModel(QAbstractTableModel):
         return True
 
     def data(self, index, role):
-        if role == Qt.DisplayRole:
+        if role == Qt.DisplayRole or role == Qt.EditRole:
             return self._table_data[index.row()][index.column()]
 
     def setData(self, index, value, role):


### PR DESCRIPTION
If one double-clicks on a cell with a value in it then the value disappears.
This is because the display role changes to "edit", so this fixes that.