### PR TITLE
Handle unnecessary empty cells copy-paste

### DIFF
--- a/nicos_ess/loki/gui/loki_scriptbuilder.py
+++ b/nicos_ess/loki/gui/loki_scriptbuilder.py
@@ -345,6 +345,10 @@ class LokiScriptBuilderPanel(LokiPanelBase):
 
         copied_table = [[x for x in row.split('\t')]
                         for row in clipboard_text.splitlines()]
+
+        if not any(data for data in sum(copied_table, [])): # flatten 2D list
+            # Don't do anything if only empty cells are copied
+            return
         if len(copied_table) == 1 and len(copied_table[0]) == 1:
             # Only one value, so put it in all selected cells
             self._do_bulk_update(copied_table[0][0])


### PR DESCRIPTION
When one selects few empty cells, and paste in the bottom of LoKI Prototype panel table, then unnecessary new rows were created. This PR fixes it.