### PR TITLE
Finish button disabled when pressed and enabled when experiment start

### DIFF
--- a/nicos/clients/gui/client.py
+++ b/nicos/clients/gui/client.py
@@ -41,7 +41,7 @@ class NicosGuiClient(NicosClient, QObject):
     failed = pyqtSignal(object, object)
     error = pyqtSignal(object)
     initstatus = pyqtSignal(object)
-    exp_prop_activated = pyqtSignal()
+    exp_proposal_activated = pyqtSignal()
 
     for evt in DAEMON_EVENTS:
         if DAEMON_EVENTS[evt][1]:

--- a/nicos/clients/gui/client.py
+++ b/nicos/clients/gui/client.py
@@ -41,6 +41,7 @@ class NicosGuiClient(NicosClient, QObject):
     failed = pyqtSignal(object, object)
     error = pyqtSignal(object)
     initstatus = pyqtSignal(object)
+    exp_prop_activated = pyqtSignal()
 
     for evt in DAEMON_EVENTS:
         if DAEMON_EVENTS[evt][1]:

--- a/nicos_ess/gui/panels/setup_panel.py
+++ b/nicos_ess/gui/panels/setup_panel.py
@@ -168,7 +168,7 @@ class ExpPanel(DefaultExpPanel):
         self._defined_data_emails = self.dataEmails.toPlainText().strip()
         self.applyWarningLabel.setVisible(False)
         self.is_exp_props_edited = [False] * self.num_experiment_props_opts
-        self.client.signal('exp_prop_activated')
+        self.client.signal('exp_proposal_activated')
 
     @pyqtSlot()
     def on_queryDBButton_clicked(self):
@@ -309,7 +309,7 @@ class FinishPanel(Panel):
         client.connected.connect(self.on_client_connected)
         client.disconnected.connect(self.on_client_disconnected)
         client.setup.connect(self.on_client_connected)
-        client.exp_prop_activated.connect(self.on_new_experiment_prop)
+        client.exp_proposal_activated.connect(self.on_new_experiment_proposal)
 
     def on_client_connected(self):
         if not self.client.viewonly:
@@ -321,7 +321,7 @@ class FinishPanel(Panel):
     def setViewOnly(self, value):
         self.finishButton.setEnabled(self.client.isconnected and not value)
 
-    def on_new_experiment_prop(self):
+    def on_new_experiment_proposal(self):
         if not self.client.viewonly:
             self.finishButton.setEnabled(True)
 
@@ -336,9 +336,9 @@ class FinishPanel(Panel):
                            'is still running.')
         else:
             self.finishButton.setEnabled(False)
-            self.finish_exp_msg_box()
+            self.show_finish_message()
 
-    def finish_exp_msg_box(self):
+    def show_finish_message(self):
         msg_box = QMessageBox()
         msg_box.setText('Experiment successfully finished.')
         return msg_box.exec_()

--- a/nicos_ess/gui/panels/setup_panel.py
+++ b/nicos_ess/gui/panels/setup_panel.py
@@ -168,6 +168,7 @@ class ExpPanel(DefaultExpPanel):
         self._defined_data_emails = self.dataEmails.toPlainText().strip()
         self.applyWarningLabel.setVisible(False)
         self.is_exp_props_edited = [False] * self.num_experiment_props_opts
+        self.client.signal('exp_prop_activated')
 
     @pyqtSlot()
     def on_queryDBButton_clicked(self):
@@ -308,6 +309,7 @@ class FinishPanel(Panel):
         client.connected.connect(self.on_client_connected)
         client.disconnected.connect(self.on_client_disconnected)
         client.setup.connect(self.on_client_connected)
+        client.exp_prop_activated.connect(self.on_new_experiment_prop)
 
     def on_client_connected(self):
         if not self.client.viewonly:
@@ -319,6 +321,10 @@ class FinishPanel(Panel):
     def setViewOnly(self, value):
         self.finishButton.setEnabled(self.client.isconnected and not value)
 
+    def on_new_experiment_prop(self):
+        if not self.client.viewonly:
+            self.finishButton.setEnabled(True)
+
     @pyqtSlot()
     def on_finishButton_clicked(self):
         if self._finish_exp_panel:
@@ -328,3 +334,11 @@ class FinishPanel(Panel):
         if self.client.run('FinishExperiment()', noqueue=True) is None:
             self.showError('Could not finish experiment, a script '
                            'is still running.')
+        else:
+            self.finishButton.setEnabled(False)
+            self.finish_exp_msg_box()
+
+    def finish_exp_msg_box(self):
+        msg_box = QMessageBox()
+        msg_box.setText('Experiment successfully finished.')
+        return msg_box.exec_()

--- a/nicos_ess/loki/gui/setup_exp.py
+++ b/nicos_ess/loki/gui/setup_exp.py
@@ -286,7 +286,7 @@ class ExpPanel(LokiPanelBase):
         self._defined_emails = self.notifEmails.toPlainText().strip()
         self.is_exp_props_edited = [False] * self.num_experiment_props_opts
         self.applyWarningLabel.setVisible(False)
-        self.client.signal('exp_prop_activated')
+        self.client.signal('exp_proposal_activated')
 
     @pyqtSlot(str)
     def on_proposalNum_textChanged(self, value):

--- a/nicos_ess/loki/gui/setup_exp.py
+++ b/nicos_ess/loki/gui/setup_exp.py
@@ -286,6 +286,7 @@ class ExpPanel(LokiPanelBase):
         self._defined_emails = self.notifEmails.toPlainText().strip()
         self.is_exp_props_edited = [False] * self.num_experiment_props_opts
         self.applyWarningLabel.setVisible(False)
+        self.client.signal('exp_prop_activated')
 
     @pyqtSlot(str)
     def on_proposalNum_textChanged(self, value):


### PR DESCRIPTION
As title says, the finish button is disabled when pressed. 
Enabled again when the user hits apply changes in the experiment setup.
Fairly simple solution that should adhere to the MV design.