### PR TITLE
Implement Float Validation

### DIFF
--- a/nicos_ess/utilities/validators.py
+++ b/nicos_ess/utilities/validators.py
@@ -1,0 +1,77 @@
+#  -*- coding: utf-8 -*-
+# *****************************************************************************
+# NICOS, the Networked Instrument Control System of the MLZ
+# Copyright (c) 2009-2021 by the NICOS contributors (see AUTHORS)
+#
+# This program is free software; you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software
+# Foundation; either version 2 of the License, or (at your option) any later
+# version.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc.,
+# 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#
+# Module authors:
+#   AÜC Hardal <umit.hardal@ess.eu>
+#
+# *****************************************************************************
+from nicos.guisupport.qt import QDoubleValidator, QValidator
+
+
+class DoubleValidator(QDoubleValidator):
+
+    def __init__(self, bottom, top, decimal=0):
+        QDoubleValidator.__init__(self)
+
+        # Required to handle manual float validation
+        self.maximum_value = top
+        self.minimum_value = bottom
+        self.decimal_precision = decimal
+
+        self.setNotation(QDoubleValidator.StandardNotation)
+        self.setRange(bottom, top, decimal)  # Required for standard validation
+
+    def validate(self, string, pos):
+        # We need to add this to have a successful float casting.
+        if string == "":
+            return QValidator.Intermediate, string, pos
+        """
+        Here we hack the QT API through `Intermediate` to be able to use
+        `.` in floats instead of `,` which QValidator expects. Try-except
+        block prevents string-types after `.` via float casting. That is, 
+        
+            >> if '.' in string:
+                   return QValidator.Intermediate, string, pos
+                
+        leads acceptable values like
+        
+            >> 12.sdaad12r..asf-dsfs1*,
+            
+        which are of course invalid. 
+        """
+        if '.' in string:
+            try:
+                if self.maximum_value > float(string) > self.minimum_value:
+                    return QValidator.Intermediate, string, pos
+            except ValueError:
+                return QValidator.Invalid, string, pos
+            finally:
+                if len(string.split('.')[1]) > self.decimal_precision:
+                    return QValidator.Invalid, string, pos
+
+        # Handle ranges in the absence of `.`, separately.
+        try:
+            if float(string) > self.maximum_value\
+                    or self.minimum_value > float(string):
+                return QValidator.Invalid, string, pos
+        except ValueError:
+            return QValidator.Invalid, string, pos
+
+        return QDoubleValidator.validate(self, string, pos)
+

--- a/nicos_ess/utilities/validators.py
+++ b/nicos_ess/utilities/validators.py
@@ -58,7 +58,7 @@ class DoubleValidator(QDoubleValidator):
         if '.' in string:
             try:
                 if self.maximum_value > float(string) > self.minimum_value:
-                    return QValidator.Intermediate, string, pos
+                    return QValidator.Acceptable, string, pos
             except ValueError:
                 return QValidator.Invalid, string, pos
             finally:

--- a/nicos_ess/utilities/validators.py
+++ b/nicos_ess/utilities/validators.py
@@ -42,9 +42,9 @@ class DoubleValidator(QDoubleValidator):
         if string == "":
             return QValidator.Intermediate, string, pos
         """
-        Here we hack the QT API through `Intermediate` to be able to use
-        `.` in floats instead of `,` which QValidator expects. Try-except
-        block prevents string-types after `.` via float casting. That is, 
+        Here we make sure to use `.` in floats instead of `,` which 
+        QValidator expects. Try-except block prevents string-types after
+        `.` via float casting. That is, 
         
             >> if '.' in string:
                    return QValidator.Intermediate, string, pos


### PR DESCRIPTION
This PR implements a validation class. The implementation sweeps all dirty work under the hood and provides a clean API such that the call

`property.setValidator(DoubleValidator(float1, float2, int))`

now is sufficient for proper validation. Here, `float1`, `float2` and `int` represents the minimum, maximum and decimal precision that `property` can assume, respectively. 

The implementation now allows inputs of the form `xx.yy` for floats instead of QT way of `xx,yy`. 

The class inherits from `QDoubleValidator` directly instead of NICOS implementation (`nicos/guisupport/utils.py, line 98`). I believe this is safer in the long run. This can be changed with no effects to implementation (with probably a change in the class name), upon consensus, if necessary.

Remaning issues:

- Numerics of the form `0xyz` (with a leading `0`) are still accepted. This can be easily handled via an additional control flow, though I want to have your opinions on this.

- The use of `locale` of QT validation. At this point I can only cross my fingers and wish NICOS server will always run from the same cold cave in Sweden :)

Notes:

- A regex solution may be designed to decrease (?) the number of lines (may be) to a similar effect. However, such a solution would be bug prone as the range `[float1, float2]` is not constant (not even mentioning the horror of decimal precision).
- I was not able to refactor the code due to how `QValidate` works. I believe this is fine.
- I can remove the comments, if you find them unnecessary, though the logic was not trivial for me.
- The code is added to `utilities` and I prefer the merge it here rather than Gerrit. Because, I believe, the other residents of the module also merged here. So, we can push all of them together when the time comes. I have no strong objection to push it to Gerrit though (other than I will use this immediately for other works, so time is important).