### PR TITLE
LoKI: Implement new validation to experiment configuration

### DIFF
--- a/nicos_ess/loki/gui/experiment_conf.py
+++ b/nicos_ess/loki/gui/experiment_conf.py
@@ -25,7 +25,7 @@
 """LoKI Experiment Configuration dialog."""
 import itertools
 
-from nicos.guisupport.qt import QMessageBox, Qt, QLineEdit
+from nicos.guisupport.qt import Qt, QLineEdit
 
 from nicos.clients.gui.utils import loadUi
 from nicos.utils import findResource

--- a/nicos_ess/loki/gui/experiment_conf.py
+++ b/nicos_ess/loki/gui/experiment_conf.py
@@ -81,10 +81,6 @@ class LokiExperimentPanel(LokiPanelBase):
         self.sampleSetApply.setEnabled(False)
         self.instSetApply.setEnabled(False)
 
-        # Required for the dynamic validation
-        self.invalid_sample_settings = []
-        self.invalid_instrument_settings = []
-
     def initialise_markups(self):
         for box in self._get_editable_settings():
             box.setAlignment(Qt.AlignRight)
@@ -148,62 +144,7 @@ class LokiExperimentPanel(LokiPanelBase):
         pass
 
     def set_ref_pos_x(self, value):
-        self._set_instrument_settings(value, value_type='ref_pos_x')
+        pass
 
     def set_ref_pos_y(self, value):
-        self._set_instrument_settings(value, value_type='ref_pos_y')
-
-    def _set_instrument_settings(self, value, value_type):
-        if not value:
-            return
-        map_value_type_to_settings = {
-            'sample': ['ref_pos_x', 'ref_pos_y'],
-            'instrument': ['apt_pos_x', 'apt_pos_y',
-                           'apt_width', 'apt_height', 'det_offset']
-        }
-        # Get settings type from value type
-        for key, values in map_value_type_to_settings.items():
-            if value_type in values:
-                settings_type = key
-                # Validate wrt settings type
-                self._validate_instrument_settings(value, value_type,
-                                                   settings_type)
-
-    def _validate_instrument_settings(self, value, value_type, settings_type):
-        # The entered value to any of the settings should be float-able.
-        # If not, this is caught by the Python runtime during casting
-        # and raises an error. We would like to warn to user without raising.
-        map_settings = {
-            'sample': (self.sampleSetApply.setEnabled,
-                       self.invalid_sample_settings),
-            'instrument': (self.instSetApply.setEnabled,
-                           self.invalid_instrument_settings)
-        }
-        map_value_type_to_setting = {
-            'apt_pos_x': self.apXBox,
-            'apt_pos_y': self.apYBox,
-            'apt_width': self.apWBox,
-            'apt_height': self.apHBox,
-            'det_offset': self.offsetBox,
-            'ref_pos_x': self.refPosXBox,
-            'ref_pos_y': self.refPosYBox
-        }
-        try:
-            float(value)
-            if value_type in map_settings[settings_type][1]:
-                map_settings[settings_type][1].remove(value_type)
-                map_value_type_to_setting[value_type]. \
-                    setClearButtonEnabled(False)
-            # Enable apply button upon validation here to prevent repetition
-            # of the code and/or misbehaviour due to multiple edits.
-            if len(map_settings[settings_type][1]) == 0:
-                map_settings[settings_type][0](True)
-            return
-        except ValueError:
-            if value_type not in map_settings[settings_type][1]:
-                QMessageBox.warning(self, 'Error',
-                                    'A value should be a number.')
-                map_settings[settings_type][1].append(value_type)
-                map_value_type_to_setting[value_type].\
-                    setClearButtonEnabled(True)
-            map_settings[settings_type][0](False)
+        pass

--- a/nicos_ess/loki/gui/experiment_conf.py
+++ b/nicos_ess/loki/gui/experiment_conf.py
@@ -25,9 +25,8 @@
 """LoKI Experiment Configuration dialog."""
 import itertools
 
-from nicos.guisupport.qt import Qt, QLineEdit
-
 from nicos.clients.gui.utils import loadUi
+from nicos.guisupport.qt import QLineEdit, Qt
 from nicos.utils import findResource
 
 from nicos_ess.loki.gui.loki_panel import LokiPanelBase

--- a/nicos_ess/loki/gui/experiment_conf.py
+++ b/nicos_ess/loki/gui/experiment_conf.py
@@ -23,12 +23,16 @@
 # *****************************************************************************
 
 """LoKI Experiment Configuration dialog."""
-from nicos.guisupport.qt import QMessageBox, Qt
+import itertools
+from collections import namedtuple
+
+from nicos.guisupport.qt import QMessageBox, Qt, QGroupBox, QLineEdit
 
 from nicos.clients.gui.utils import loadUi
 from nicos.utils import findResource
 
 from nicos_ess.loki.gui.loki_panel import LokiPanelBase
+from nicos_ess.utilities.validators import DoubleValidator
 
 
 class LokiExperimentPanel(LokiPanelBase):
@@ -42,6 +46,7 @@ class LokiExperimentPanel(LokiPanelBase):
         self.instrument = options.get('instrument', 'loki')
         self.initialise_connection_status_listeners()
         self.initialise_markups()
+        self.initialise_validators()
 
         self.envComboBox.addItems(['Sample Changer A', 'Sample Changer B'])
         # Start with a "no item", ie, empty selection.
@@ -90,6 +95,25 @@ class LokiExperimentPanel(LokiPanelBase):
             box.setAlignment(Qt.AlignRight)
             box.setPlaceholderText('0.0')
 
+    def initialise_validators(self):
+        _validator_values = {  # in units of mm
+            'bottom': 0.0,
+            'top': 1000.0,
+            'decimal': 5,
+        }
+        validator = DoubleValidator(**_validator_values)
+        for box in self._get_editable_settings():
+            box.setValidator(validator)
+
+    def _get_editable_settings(self):
+        _editable_settings = list(
+            itertools.chain(
+                self.aptGroupBox.findChildren(QLineEdit),
+                self.detGroupBox.findChildren(QLineEdit)
+            )
+        )
+        return _editable_settings
+
     def setViewOnly(self, viewonly):
         self.sampleSetGroupBox.setEnabled(not viewonly)
         self.instSetGroupBox.setEnabled(not viewonly)
@@ -114,19 +138,19 @@ class LokiExperimentPanel(LokiPanelBase):
         pass
 
     def set_det_offset(self, value):
-        self._set_instrument_settings(value, value_type='det_offset')
+        pass
 
     def set_apt_pos_x(self, value):
-        self._set_instrument_settings(value, value_type='apt_pos_x')
+        pass
 
     def set_apt_pos_y(self, value):
-        self._set_instrument_settings(value, value_type='apt_pos_y')
+        pass
 
     def set_apt_width(self, value):
-        self._set_instrument_settings(value, value_type='apt_width')
+        pass
 
     def set_apt_height(self, value):
-        self._set_instrument_settings(value, value_type='apt_height')
+        pass
 
     def set_ref_pos_x(self, value):
         self._set_instrument_settings(value, value_type='ref_pos_x')

--- a/nicos_ess/loki/gui/experiment_conf.py
+++ b/nicos_ess/loki/gui/experiment_conf.py
@@ -24,9 +24,8 @@
 
 """LoKI Experiment Configuration dialog."""
 import itertools
-from collections import namedtuple
 
-from nicos.guisupport.qt import QMessageBox, Qt, QGroupBox, QLineEdit
+from nicos.guisupport.qt import QMessageBox, Qt, QLineEdit
 
 from nicos.clients.gui.utils import loadUi
 from nicos.utils import findResource
@@ -87,11 +86,7 @@ class LokiExperimentPanel(LokiPanelBase):
         self.invalid_instrument_settings = []
 
     def initialise_markups(self):
-        setting_boxes = [
-            self.apXBox, self.apYBox, self.apWBox, self.apHBox,
-            self.offsetBox, self.refPosXBox, self.refPosYBox
-        ]
-        for box in setting_boxes:
+        for box in self._get_editable_settings():
             box.setAlignment(Qt.AlignRight)
             box.setPlaceholderText('0.0')
 
@@ -212,4 +207,3 @@ class LokiExperimentPanel(LokiPanelBase):
                 map_value_type_to_setting[value_type].\
                     setClearButtonEnabled(True)
             map_settings[settings_type][0](False)
-

--- a/nicos_ess/loki/gui/experiment_conf.py
+++ b/nicos_ess/loki/gui/experiment_conf.py
@@ -96,12 +96,10 @@ class LokiExperimentPanel(LokiPanelBase):
             box.setValidator(validator)
 
     def _get_editable_settings(self):
-        _editable_settings = list(
-            itertools.chain(
+        _editable_settings = itertools.chain(
                 self.aptGroupBox.findChildren(QLineEdit),
                 self.detGroupBox.findChildren(QLineEdit)
             )
-        )
         return _editable_settings
 
     def setViewOnly(self, viewonly):

--- a/nicos_ess/loki/gui/ui_files/exp_config.ui
+++ b/nicos_ess/loki/gui/ui_files/exp_config.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>1159</width>
-    <height>739</height>
+    <height>747</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -290,6 +290,9 @@
               <property name="layoutDirection">
                <enum>Qt::RightToLeft</enum>
               </property>
+              <property name="readOnly">
+               <bool>true</bool>
+              </property>
              </widget>
             </item>
             <item row="1" column="2">
@@ -310,6 +313,9 @@
              <widget class="QLineEdit" name="refPosYBox">
               <property name="layoutDirection">
                <enum>Qt::RightToLeft</enum>
+              </property>
+              <property name="readOnly">
+               <bool>true</bool>
               </property>
              </widget>
             </item>


### PR DESCRIPTION
This PR implements new `DoubleValidator` to Experiment Configuration tab of LoKI GUI, and clears the unnecessary code up.
The sample environment reface positions now read-only as a prep for next iteration of implementation of devices.