### PR TITLE
ECDC-2549: Send regular updates from cache to kafka

### DIFF
--- a/nicos_ess/devices/cache_kafka_forwarder.py
+++ b/nicos_ess/devices/cache_kafka_forwarder.py
@@ -124,7 +124,7 @@ class CacheKafkaForwarder(ForwarderBase, Device):
             with self._lock:
                 for dev_name in set(self._dev_to_value_cache.keys()).union(
                         self._dev_to_status_cache.keys()):
-                    if self._timestamp_and_value_and_status_available(dev_name):
+                    if self._relevant_properties_available(dev_name):
                         self._push_to_queue(
                             dev_name,
                             self._dev_to_value_cache[dev_name],
@@ -160,14 +160,14 @@ class CacheKafkaForwarder(ForwarderBase, Device):
             timestamp_ns = int(float(timestamp) * 10 ** 9)
             self._dev_to_timestamp_cache[dev_name] = timestamp_ns
             # Don't send until have at least one reading for both value and status
-            if self._timestamp_and_value_and_status_available(dev_name):
+            if self._relevant_properties_available(dev_name):
                 self._push_to_queue(
                     dev_name,
                     self._dev_to_value_cache[dev_name],
                     self._dev_to_status_cache[dev_name],
                     timestamp_ns,)
 
-    def _timestamp_and_value_and_status_available(self, dev_name):
+    def _relevant_properties_available(self, dev_name):
         return dev_name in self._dev_to_value_cache \
             and dev_name in self._dev_to_status_cache \
             and dev_name in self._dev_to_timestamp_cache

--- a/nicos_ess/devices/cache_kafka_forwarder.py
+++ b/nicos_ess/devices/cache_kafka_forwarder.py
@@ -103,7 +103,7 @@ class CacheKafkaForwarder(ForwarderBase, Device):
         self._worker = createThread('cache_to_kafka', self._processQueue,
                                     start=False)
         self._regular_update_worker = createThread(
-            'send_regular_updates', self._send_regular_updates, start=False)
+            'send_regular_updates', self._poll_updates, start=False)
         while not self._producer:
             try:
                 self._producer = \
@@ -119,13 +119,12 @@ class CacheKafkaForwarder(ForwarderBase, Device):
         self._worker.start()
         self._regular_update_worker.start()
 
-    def _send_regular_updates(self):
+    def _poll_updates(self):
         while True:
             with self._lock:
-                devices = set(
+                for dev_name in set(
                     self._dev_to_value_cache.keys()).union(
-                        self._dev_to_status_cache.keys())
-                for dev_name in devices:
+                        self._dev_to_status_cache.keys()):
                     if self._value_and_status_available(dev_name):
                         timestamp = self._dev_to_timestamp_cache[dev_name]
                         value = self._dev_to_value_cache[dev_name]

--- a/nicos_ess/devices/cache_kafka_forwarder.py
+++ b/nicos_ess/devices/cache_kafka_forwarder.py
@@ -122,14 +122,16 @@ class CacheKafkaForwarder(ForwarderBase, Device):
     def _poll_updates(self):
         while True:
             with self._lock:
-                for dev_name in set(
-                    self._dev_to_value_cache.keys()).union(
+                for dev_name in set(self._dev_to_value_cache.keys()).union(
                         self._dev_to_status_cache.keys()):
                     if self._value_and_status_available(dev_name):
-                        timestamp = self._dev_to_timestamp_cache[dev_name]
-                        value = self._dev_to_value_cache[dev_name]
-                        status = self._dev_to_status_cache[dev_name]
-                        self._push_to_queue(timestamp, dev_name, value, status)
+                        try:
+                            timestamp = self._dev_to_timestamp_cache[dev_name]
+                            value = self._dev_to_value_cache[dev_name]
+                            status = self._dev_to_status_cache[dev_name]
+                            self._push_to_queue(timestamp, dev_name, value, status)
+                        except KeyError:
+                            pass
 
             time.sleep(self.update_interval)
 

--- a/nicos_ess/devices/cache_kafka_forwarder.py
+++ b/nicos_ess/devices/cache_kafka_forwarder.py
@@ -83,7 +83,7 @@ class CacheKafkaForwarder(ForwarderBase, Device):
                             type=listof(str),
                             ),
         'update_interval': Param('Time interval (in secs.) to send regular updates',
-                                 default=10.0, type=float)
+                                 default=10.0, type=float, settable=False)
 
     }
     parameter_overrides = {

--- a/nicos_ess/devices/cache_kafka_forwarder.py
+++ b/nicos_ess/devices/cache_kafka_forwarder.py
@@ -125,7 +125,11 @@ class CacheKafkaForwarder(ForwarderBase, Device):
                     self._dev_to_value_cache.keys()).union(
                         self._dev_to_status_cache.keys())
                 for dev_name in devices:
-                    self._push_to_queue(time.time(), dev_name)
+                    if self._value_and_status_available(dev_name):
+                        value = self._dev_to_value_cache[dev_name]
+                        status = self._dev_to_status_cache[dev_name]
+                        self._push_to_queue(time.time(), dev_name, value, status)
+
             time.sleep(self.update_interval)
 
     def _checkKey(self, key):
@@ -151,21 +155,26 @@ class CacheKafkaForwarder(ForwarderBase, Device):
                 self._dev_to_value_cache[dev_name] = value
             else:
                 self._dev_to_status_cache[dev_name] = convert_status(value)
+            # Don't send until have at least one reading for both value and status
+            if self._value_and_status_available(dev_name):
+                value = self._dev_to_value_cache[dev_name]
+                status = self._dev_to_status_cache[dev_name]
+                self._push_to_queue(time, dev_name, value, status)
 
-            self._push_to_queue(time, dev_name)
+    def _value_and_status_available(self, dev_name):
+        if dev_name in self._dev_to_value_cache \
+            and dev_name in self._dev_to_status_cache:
+            return True
+        return False
 
-    def _push_to_queue(self, time, dev_name):
-        # Don't send until have at least one reading for both value and status
-        if dev_name in self._dev_to_value_cache and \
-                dev_name in self._dev_to_status_cache:
-            try:
-                self._queue.put((dev_name, self._dev_to_value_cache[dev_name],
-                                 self._dev_to_status_cache[dev_name],
-                                 int(float(time) * 10 ** 9)))
-            except queue.Full:
-                self.log.error('Queue full, so discarding older value(s)')
-                self._queue.get()
-                self._queue.task_done()
+    def _push_to_queue(self, time, dev_name, value, status):
+        try:
+            self._queue.put(
+                (dev_name, value, status, int(float(time) * 10 ** 9)))
+        except queue.Full:
+            self.log.error('Queue full, so discarding older value(s)')
+            self._queue.get()
+            self._queue.task_done()
 
     def _processQueue(self):
         while True:

--- a/nicos_ess/devices/cache_kafka_forwarder.py
+++ b/nicos_ess/devices/cache_kafka_forwarder.py
@@ -23,6 +23,7 @@
 # *****************************************************************************
 import queue
 import time
+from threading import Lock
 
 from kafka import KafkaProducer
 from streaming_data_types.fbschemas.logdata_f142.AlarmSeverity import \
@@ -81,6 +82,8 @@ class CacheKafkaForwarder(ForwarderBase, Device):
                             'accepted', default=[],
                             type=listof(str),
                             ),
+        'update_interval': Param('Time interval (in secs.) to send regular updates',
+                                 default=1.0, type=float)
 
     }
     parameter_overrides = {
@@ -92,11 +95,14 @@ class CacheKafkaForwarder(ForwarderBase, Device):
         self._dev_to_value_cache = {}
         self._dev_to_status_cache = {}
         self._producer = None
+        self._lock = Lock()
 
         self._initFilters()
         self._queue = queue.Queue(1000)
         self._worker = createThread('cache_to_kafka', self._processQueue,
                                     start=False)
+        self._regular_update_worker = createThread(
+            'send_regular_updates', self._send_regular_updates, start=False)
         while not self._producer:
             try:
                 self._producer = \
@@ -110,6 +116,17 @@ class CacheKafkaForwarder(ForwarderBase, Device):
 
     def _startWorker(self):
         self._worker.start()
+        self._regular_update_worker.start()
+
+    def _send_regular_updates(self):
+        while True:
+            with self._lock:
+                devices = set(
+                    self._dev_to_value_cache.keys()).union(
+                        self._dev_to_status_cache.keys())
+                for dev_name in devices:
+                    self._push_to_queue(time.time(), dev_name)
+            time.sleep(self.update_interval)
 
     def _checkKey(self, key):
         if key.endswith('/value') or key.endswith('/status'):
@@ -129,11 +146,15 @@ class CacheKafkaForwarder(ForwarderBase, Device):
             return
         self.log.debug('_putChange %s %s %s', key, value, time)
 
-        if key.endswith('value'):
-            self._dev_to_value_cache[dev_name] = value
-        else:
-            self._dev_to_status_cache[dev_name] = convert_status(value)
+        with self._lock:
+            if key.endswith('value'):
+                self._dev_to_value_cache[dev_name] = value
+            else:
+                self._dev_to_status_cache[dev_name] = convert_status(value)
 
+            self._push_to_queue(time, dev_name)
+
+    def _push_to_queue(self, time, dev_name):
         # Don't send until have at least one reading for both value and status
         if dev_name in self._dev_to_value_cache and \
                 dev_name in self._dev_to_status_cache:

--- a/nicos_ess/devices/cache_kafka_forwarder.py
+++ b/nicos_ess/devices/cache_kafka_forwarder.py
@@ -126,10 +126,10 @@ class CacheKafkaForwarder(ForwarderBase, Device):
                         self._dev_to_status_cache.keys()):
                     if self._timestamp_and_value_and_status_available(dev_name):
                         self._push_to_queue(
-                            self._dev_to_timestamp_cache[dev_name],
                             dev_name,
                             self._dev_to_value_cache[dev_name],
-                            self._dev_to_status_cache[dev_name])
+                            self._dev_to_status_cache[dev_name],
+                            self._dev_to_timestamp_cache[dev_name])
 
             time.sleep(self.update_interval)
 
@@ -162,17 +162,17 @@ class CacheKafkaForwarder(ForwarderBase, Device):
             # Don't send until have at least one reading for both value and status
             if self._timestamp_and_value_and_status_available(dev_name):
                 self._push_to_queue(
-                    timestamp_ns,
                     dev_name,
                     self._dev_to_value_cache[dev_name],
-                    self._dev_to_status_cache[dev_name])
+                    self._dev_to_status_cache[dev_name],
+                    timestamp_ns,)
 
     def _timestamp_and_value_and_status_available(self, dev_name):
         return dev_name in self._dev_to_value_cache \
             and dev_name in self._dev_to_status_cache \
             and dev_name in self._dev_to_timestamp_cache
 
-    def _push_to_queue(self, timestamp, dev_name, value, status):
+    def _push_to_queue(self, dev_name, value, status, timestamp):
         try:
             self._queue.put(
                 (dev_name, value, status, timestamp))

--- a/nicos_ess/devices/cache_kafka_forwarder.py
+++ b/nicos_ess/devices/cache_kafka_forwarder.py
@@ -174,11 +174,11 @@ class CacheKafkaForwarder(ForwarderBase, Device):
 
     def _push_to_queue(self, dev_name, value, status, timestamp):
         try:
-            self._queue.put(
-                (dev_name, value, status, timestamp))
+            self._queue._put_nowait((dev_name, value, status, timestamp))
         except queue.Full:
             self.log.error('Queue full, so discarding older value(s)')
             self._queue.get()
+            self._queue.put((dev_name, value, status, timestamp))
             self._queue.task_done()
 
     def _processQueue(self):

--- a/nicos_ess/devices/cache_kafka_forwarder.py
+++ b/nicos_ess/devices/cache_kafka_forwarder.py
@@ -94,6 +94,7 @@ class CacheKafkaForwarder(ForwarderBase, Device):
     def doInit(self, mode):
         self._dev_to_value_cache = {}
         self._dev_to_status_cache = {}
+        self._dev_to_timestamp_cache = {}
         self._producer = None
         self._lock = Lock()
 
@@ -126,9 +127,10 @@ class CacheKafkaForwarder(ForwarderBase, Device):
                         self._dev_to_status_cache.keys())
                 for dev_name in devices:
                     if self._value_and_status_available(dev_name):
+                        timestamp = self._dev_to_timestamp_cache[dev_name]
                         value = self._dev_to_value_cache[dev_name]
                         status = self._dev_to_status_cache[dev_name]
-                        self._push_to_queue(time.time(), dev_name, value, status)
+                        self._push_to_queue(timestamp, dev_name, value, status)
 
             time.sleep(self.update_interval)
 
@@ -142,7 +144,7 @@ class CacheKafkaForwarder(ForwarderBase, Device):
             return True
         return False
 
-    def _putChange(self, time, ttl, key, value):
+    def _putChange(self, timestamp, ttl, key, value):
         if value is None:
             return
         dev_name = key[0:key.index('/')]
@@ -155,11 +157,12 @@ class CacheKafkaForwarder(ForwarderBase, Device):
                 self._dev_to_value_cache[dev_name] = value
             else:
                 self._dev_to_status_cache[dev_name] = convert_status(value)
+            self._dev_to_timestamp_cache[dev_name] = timestamp
             # Don't send until have at least one reading for both value and status
             if self._value_and_status_available(dev_name):
                 value = self._dev_to_value_cache[dev_name]
                 status = self._dev_to_status_cache[dev_name]
-                self._push_to_queue(time, dev_name, value, status)
+                self._push_to_queue(timestamp, dev_name, value, status)
 
     def _value_and_status_available(self, dev_name):
         if dev_name in self._dev_to_value_cache \
@@ -167,10 +170,10 @@ class CacheKafkaForwarder(ForwarderBase, Device):
             return True
         return False
 
-    def _push_to_queue(self, time, dev_name, value, status):
+    def _push_to_queue(self, timestamp, dev_name, value, status):
         try:
             self._queue.put(
-                (dev_name, value, status, int(float(time) * 10 ** 9)))
+                (dev_name, value, status, int(float(timestamp) * 10 ** 9)))
         except queue.Full:
             self.log.error('Queue full, so discarding older value(s)')
             self._queue.get()

--- a/nicos_ess/devices/cache_kafka_forwarder.py
+++ b/nicos_ess/devices/cache_kafka_forwarder.py
@@ -83,7 +83,7 @@ class CacheKafkaForwarder(ForwarderBase, Device):
                             type=listof(str),
                             ),
         'update_interval': Param('Time interval (in secs.) to send regular updates',
-                                 default=1.0, type=float)
+                                 default=10.0, type=float)
 
     }
     parameter_overrides = {
@@ -124,14 +124,12 @@ class CacheKafkaForwarder(ForwarderBase, Device):
             with self._lock:
                 for dev_name in set(self._dev_to_value_cache.keys()).union(
                         self._dev_to_status_cache.keys()):
-                    if self._value_and_status_available(dev_name):
-                        try:
-                            timestamp = self._dev_to_timestamp_cache[dev_name]
-                            value = self._dev_to_value_cache[dev_name]
-                            status = self._dev_to_status_cache[dev_name]
-                            self._push_to_queue(timestamp, dev_name, value, status)
-                        except KeyError:
-                            pass
+                    if self._timestamp_and_value_and_status_available(dev_name):
+                        self._push_to_queue(
+                            self._dev_to_timestamp_cache[dev_name],
+                            dev_name,
+                            self._dev_to_value_cache[dev_name],
+                            self._dev_to_status_cache[dev_name])
 
             time.sleep(self.update_interval)
 
@@ -158,23 +156,26 @@ class CacheKafkaForwarder(ForwarderBase, Device):
                 self._dev_to_value_cache[dev_name] = value
             else:
                 self._dev_to_status_cache[dev_name] = convert_status(value)
-            self._dev_to_timestamp_cache[dev_name] = timestamp
-            # Don't send until have at least one reading for both value and status
-            if self._value_and_status_available(dev_name):
-                value = self._dev_to_value_cache[dev_name]
-                status = self._dev_to_status_cache[dev_name]
-                self._push_to_queue(timestamp, dev_name, value, status)
 
-    def _value_and_status_available(self, dev_name):
-        if dev_name in self._dev_to_value_cache \
-            and dev_name in self._dev_to_status_cache:
-            return True
-        return False
+            timestamp_ns = int(float(timestamp) * 10 ** 9)
+            self._dev_to_timestamp_cache[dev_name] = timestamp_ns
+            # Don't send until have at least one reading for both value and status
+            if self._timestamp_and_value_and_status_available(dev_name):
+                self._push_to_queue(
+                    timestamp_ns,
+                    dev_name,
+                    self._dev_to_value_cache[dev_name],
+                    self._dev_to_status_cache[dev_name])
+
+    def _timestamp_and_value_and_status_available(self, dev_name):
+        return dev_name in self._dev_to_value_cache \
+            and dev_name in self._dev_to_status_cache \
+            and dev_name in self._dev_to_timestamp_cache
 
     def _push_to_queue(self, timestamp, dev_name, value, status):
         try:
             self._queue.put(
-                (dev_name, value, status, int(float(timestamp) * 10 ** 9)))
+                (dev_name, value, status, timestamp))
         except queue.Full:
             self.log.error('Queue full, so discarding older value(s)')
             self._queue.get()


### PR DESCRIPTION
Now sends regular updates of device's ` (value, status and time (when the last update happened))`  from cache to kafka. `update_interval` is reconfigurable.