### PR TITLE
ECDC-2551 make motor speed adjustable

### DIFF
--- a/nicos_ess/devices/epics/pva/epics_devices.py
+++ b/nicos_ess/devices/epics/pva/epics_devices.py
@@ -314,10 +314,6 @@ class EpicsMoveable(EpicsMonitorMixin, EpicsDevice, Moveable):
 
         return {'readpv', 'writepv'}
 
-    def _get_speed_limits(self):
-        return self._epics_wrapper.get_limits(self._get_pv_name('speed'),
-                                              timeout=self.epicstimeout)
-
     def doInit(self, mode):
         if mode == SIMULATION:
             return

--- a/nicos_ess/devices/epics/pva/epics_devices.py
+++ b/nicos_ess/devices/epics/pva/epics_devices.py
@@ -210,6 +210,10 @@ class EpicsDevice(DeviceMixinBase):
             for key in self._pvs:
                 self._pvs[key] = HardwareStub(self)
 
+    def _get_limits(self, pvparam):
+        self._epics_wrapper.get_limits(self._get_pv_name(pvparam),
+                                       timeout=self.epicstimeout)
+
     def _get_pv(self, pvparam, as_string=False):
         return self._epics_wrapper.get_pv_value(self._pvs[pvparam],
                                                 timeout=self.epicstimeout,

--- a/nicos_ess/devices/epics/pva/epics_devices.py
+++ b/nicos_ess/devices/epics/pva/epics_devices.py
@@ -314,6 +314,12 @@ class EpicsMoveable(EpicsMonitorMixin, EpicsDevice, Moveable):
 
         return {'readpv', 'writepv'}
 
+    def _get_speed_limits(self):
+        pvname = self._get_pv_name('speed')
+        session.log.error(f'PV NAME: {pvname}')
+        return self._epics_wrapper.get_limits(self._get_pv_name('speed'),
+                                              timeout=self.epicstimeout)
+
     def doInit(self, mode):
         if mode == SIMULATION:
             return

--- a/nicos_ess/devices/epics/pva/epics_devices.py
+++ b/nicos_ess/devices/epics/pva/epics_devices.py
@@ -315,8 +315,6 @@ class EpicsMoveable(EpicsMonitorMixin, EpicsDevice, Moveable):
         return {'readpv', 'writepv'}
 
     def _get_speed_limits(self):
-        pvname = self._get_pv_name('speed')
-        session.log.error(f'PV NAME: {pvname}')
         return self._epics_wrapper.get_limits(self._get_pv_name('speed'),
                                               timeout=self.epicstimeout)
 

--- a/nicos_ess/devices/epics/pva/epics_devices.py
+++ b/nicos_ess/devices/epics/pva/epics_devices.py
@@ -211,8 +211,8 @@ class EpicsDevice(DeviceMixinBase):
                 self._pvs[key] = HardwareStub(self)
 
     def _get_limits(self, pvparam):
-        self._epics_wrapper.get_limits(self._get_pv_name(pvparam),
-                                       timeout=self.epicstimeout)
+        return self._epics_wrapper.get_limits(self._get_pv_name(pvparam),
+                                              timeout=self.epicstimeout)
 
     def _get_pv(self, pvparam, as_string=False):
         return self._epics_wrapper.get_pv_value(self._pvs[pvparam],

--- a/nicos_ess/devices/epics/pva/monitor_motor.py
+++ b/nicos_ess/devices/epics/pva/monitor_motor.py
@@ -299,8 +299,7 @@ class EpicsMotor(CanDisable, CanReference, HasOffset, EpicsMoveable, Motor):
         return status.OK
 
     def _get_speed_limits(self):
-        return self._epics_wrapper.get_limits(self._get_pv_name('speed'),
-                                              timeout=self.epicstimeout)
+        return self._get_limits('speed')
 
     def doStop(self):
         self._put_pv('stop', 1, False)

--- a/nicos_ess/devices/epics/pva/monitor_motor.py
+++ b/nicos_ess/devices/epics/pva/monitor_motor.py
@@ -298,6 +298,10 @@ class EpicsMotor(CanDisable, CanReference, HasOffset, EpicsMoveable, Motor):
             return status.UNKNOWN
         return status.OK
 
+    def _get_speed_limits(self):
+        return self._epics_wrapper.get_limits(self._get_pv_name('speed'),
+                                              timeout=self.epicstimeout)
+
     def doStop(self):
         self._put_pv('stop', 1, False)
 

--- a/nicos_ess/devices/epics/pva/monitor_motor.py
+++ b/nicos_ess/devices/epics/pva/monitor_motor.py
@@ -201,9 +201,7 @@ class EpicsMotor(CanDisable, CanReference, HasOffset, EpicsMoveable, Motor):
         self.offset -= diff
 
     def _get_valid_speed(self, newValue):
-        min_speed = self._get_pvctrl('speed', 'lower_ctrl_limit', 0.0)
-        max_speed = self._get_pvctrl('speed', 'upper_ctrl_limit', 0.0)
-
+        min_speed, max_speed = self._get_speed_limits()
         valid_speed = newValue
         if min_speed != 0.0:
             valid_speed = max(min_speed, valid_speed)


### PR DESCRIPTION
Added capability to set the speed for p4p epics motor device.
@mattclarke I have tested on YMIR. Feel free to take a look yourself.
Branch with local edits (session logging of limits) is still active on ymir server.