### PR TITLE
ECDC:2560 Finish Experiment should clear the samples.

### DIFF
--- a/nicos_ess/devices/experiment.py
+++ b/nicos_ess/devices/experiment.py
@@ -29,7 +29,7 @@ import os
 from yuos_query.exceptions import BaseYuosException
 from yuos_query.yuos_client import YuosClient
 
-from nicos.core import Override, Param
+from nicos.core import Override, Param, usermethod
 from nicos.devices.experiment import Experiment
 
 
@@ -130,3 +130,9 @@ class EssExperiment(Experiment):
                 }
             )
         return users
+
+    @usermethod
+    def new(self, proposal, title=None, localcontact=None, user=None, **kwds):
+        Experiment.new(
+            self, proposal, title=None, localcontact=None, user=None, **kwds)
+        self.sample.clear()

--- a/nicos_ess/devices/sample.py
+++ b/nicos_ess/devices/sample.py
@@ -41,10 +41,3 @@ class EssSample(Sample):
                              category='sample'),
         'density': Param('density', type=str, settable=True, category='sample'),
     }
-
-    def new(self, parameters):
-        # EssSample being set using NewSample should have sample_name?
-        # i.e. parameter in NewSample(name, **parameters) must also have
-        # sample_name key.
-        if 'sample_name' in parameters:
-            Sample.new(self, parameters)

--- a/nicos_ess/devices/sample.py
+++ b/nicos_ess/devices/sample.py
@@ -41,3 +41,10 @@ class EssSample(Sample):
                              category='sample'),
         'density': Param('density', type=str, settable=True, category='sample'),
     }
+
+    def new(self, parameters):
+        # EssSample being set using NewSample should have sample_name?
+        # i.e. parameter in NewSample(name, **parameters) must also have
+        # sample_name key.
+        if 'sample_name' in parameters:
+            Sample.new(self, parameters)


### PR DESCRIPTION
This PR tries to fix issue observed while FinishExperiment command is called. In `_update_proposal_info` in setup_panel, the  `Exp.sample.samples`  evaluates to` {0:{'name':''}}`, rather than an empty dictionary.