### PR TITLE
ECDC-2575 Make finish button multi-client friendly

### DIFF
--- a/nicos/clients/flowui/mainwindow.py
+++ b/nicos/clients/flowui/mainwindow.py
@@ -56,11 +56,6 @@ class MainWindow(DefaultMainWindow):
         self.set_icons()
         self.style_file = gui_conf.stylefile
 
-        # Connect widget events.
-        self.getPanel('Experiment setup').exp_proposal_activated.connect(
-            self.getPanel('Finish experiment').on_new_experiment_proposal
-        )
-
         # Cheeseburger menu
         dropdown = QMenu('')
         dropdown.addAction(self.actionConnect)

--- a/nicos_ess/gui/panels/setup_panel.py
+++ b/nicos_ess/gui/panels/setup_panel.py
@@ -511,28 +511,33 @@ class FinishPanel(Panel):
         loadUi(self, self.ui)
         self._finish_exp_panel = None
 
-        # Additional dialog panels to pop up after FinishExperiment().
+        # Additional dialog panel to pop up after FinishExperiment().
         self._finish_exp_panel = options.get('finish_exp_panel')
+
         self.finishButton.setEnabled(False)
         client.connected.connect(self.on_client_connected)
         client.disconnected.connect(self.on_client_disconnected)
-        client.setup.connect(self.on_client_connected)
+        client.experiment.connect(self.on_experiment_changed)
 
-        self._experiment_finished = False
+    def on_experiment_changed(self, a):
+        self._enable_finishing()
+
+    def _enable_finishing(self):
+        if not self.client.viewonly and \
+                self.client.eval('session.experiment.proptype', 'user') \
+                == 'user':
+            self.finishButton.setEnabled(True)
+        else:
+            self.finishButton.setEnabled(False)
 
     def on_client_connected(self):
-        self.finishButton.setEnabled(not self._experiment_finished)
+        self._enable_finishing()
 
     def on_client_disconnected(self):
         self.finishButton.setEnabled(False)
 
     def setViewOnly(self, value):
-        self.finishButton.setEnabled(self.client.isconnected and not value)
-
-    def on_new_experiment_proposal(self):
-        if not self.client.viewonly:
-            self.finishButton.setEnabled(True)
-        self._experiment_finished = False
+        self._enable_finishing()
 
     @pyqtSlot()
     def on_finishButton_clicked(self):
@@ -544,8 +549,7 @@ class FinishPanel(Panel):
             self.showError('Could not finish experiment, a script '
                            'is still running.')
         else:
-            self.finishButton.setEnabled(False)
-            self._experiment_finished = True
+            self._enable_finishing()
             self.show_finish_message()
 
     def show_finish_message(self):

--- a/nicos_ess/gui/panels/setup_panel.py
+++ b/nicos_ess/gui/panels/setup_panel.py
@@ -549,7 +549,6 @@ class FinishPanel(Panel):
             self.showError('Could not finish experiment, a script '
                            'is still running.')
         else:
-            self._enable_finishing()
             self.show_finish_message()
 
     def show_finish_message(self):

--- a/nicos_ess/gui/panels/setup_panel.py
+++ b/nicos_ess/gui/panels/setup_panel.py
@@ -523,12 +523,13 @@ class FinishPanel(Panel):
         self._enable_finishing()
 
     def _enable_finishing(self):
-        if not self.client.viewonly and \
-                self.client.eval('session.experiment.proptype', 'user') \
-                == 'user':
+        if not self.client.viewonly and self._is_user_experiment():
             self.finishButton.setEnabled(True)
         else:
             self.finishButton.setEnabled(False)
+
+    def _is_user_experiment(self):
+        return self.client.eval('session.experiment.proptype', 'user') == 'user'
 
     def on_client_connected(self):
         self._enable_finishing()


### PR DESCRIPTION
This sets it up so that all clients respond to a "finish" event, not just the one where finish was clicked.