### PR TITLE
LoKI: Change menu order

### DIFF
--- a/nicos_ess/loki/guiconfig.py
+++ b/nicos_ess/loki/guiconfig.py
@@ -15,16 +15,16 @@ main_window = docked(
                 (panel('nicos.clients.flowui.panels.setup_panel.SetupsPanel'))
             ),  # vsplit
         ),
-(
-            'Samples',
-            vsplit(
-                (panel('nicos_ess.loki.gui.loki_samples.LokiSamplePanel'))
-            ),  # vsplit
-        ),
         (
             'Experiment Configuration',
             vsplit(
                 (panel('nicos_ess.loki.gui.experiment_conf.LokiExperimentPanel'))
+            ),  # vsplit
+        ),
+        (
+            'Samples',
+            vsplit(
+                (panel('nicos_ess.loki.gui.loki_samples.LokiSamplePanel'))
             ),  # vsplit
         ),
         ('  ', panel('nicos.clients.flowui.panels.empty.EmptyPanel')),


### PR DESCRIPTION
This changes the order at the left menu, `Experiment Configuration` now comes before `Samples`.