### PR TITLE
ECDC-2589: Rename chopper devices at YMIR instrument

### DIFF
--- a/nicos_ess/ymir/setups/choppers.py
+++ b/nicos_ess/ymir/setups/choppers.py
@@ -3,12 +3,12 @@ description = 'The mini-chopper for YMIR'
 pv_root = 'Utg-Ymir:Chop-Drv-0101:'
 
 devices = dict(
-    Chopper_status=device(
+    mini_chopper_status=device(
         'nicos.devices.epics.EpicsStringReadable',
         description='The chopper status.',
         readpv='{}Chop_Stat'.format(pv_root),
     ),
-    Chopper_control=device(
+    mini_chopper_control=device(
         'nicos_ess.devices.epics.extensions.EpicsMappedMoveable',
         description='Used to start and stop the chopper.',
         readpv='{}Cmd'.format(pv_root),
@@ -20,14 +20,14 @@ devices = dict(
                  'Reset chopper': 1,
         },
     ),
-    Chopper_speed=device(
+    mini_chopper_speed=device(
         'nicos_ess.devices.epics.pva.EpicsAnalogMoveable',
         description='The current speed.',
         readpv='{}Spd_Stat'.format(pv_root),
         writepv='{}Spd_SP'.format(pv_root),
         abslimits=(0.0, 14),
     ),
-    Chopper_delay=device(
+    mini_chopper_delay=device(
         'nicos_ess.devices.epics.pva.EpicsAnalogMoveable',
         description='The current delay.',
         readpv='{}Chopper-Delay-SP'.format(pv_root),


### PR DESCRIPTION
Renaming chopper devices at YMIR, as suggested in the ticket https://jira.esss.lu.se/browse/ECDC-2589