### PR TITLE
Restore the chopper device

### DIFF
--- a/nicos_ess/devices/epics/mini_chopper.py
+++ b/nicos_ess/devices/epics/mini_chopper.py
@@ -21,12 +21,12 @@
 #   Michael Wedel <michael.wedel@esss.se>
 #   Nikhil Biyani <nikhil.biyani@psi.ch>
 #   Michael Hart <michael.hart@stfc.ac.uk>
+#   Matt Clarke <matt.clarke@ess.eu>
 #
 # *****************************************************************************
 
-from nicos.core import Attach, Moveable, Override, status, \
-    tupleof, usermethod, Readable
-from nicos.devices.epics import EpicsMoveable, EpicsReadable
+from nicos.core import Attach, Moveable, Override, Readable, status, tupleof, \
+    usermethod
 
 
 class EssChopper(Moveable):
@@ -34,12 +34,16 @@ class EssChopper(Moveable):
         'speed': Attach('Speed of the chopper disc.', Moveable),
         'phase': Attach('Phase of the chopper disc', Moveable),
         'state': Attach('Current state of the chopper', Readable),
-        # 'command': Attach('Command PV of the chopper', EpicsMoveable)
+        'command': Attach('Command PV of the chopper', Moveable)
     }
 
     parameter_overrides = {
         'fmtstr': Override(default='Speed=%.2f Delay=%.2f'),
         'unit': Override(mandatory=False),
+    }
+
+    _commands = {
+        'start', 'stop', 'reset',
     }
 
     hardware_access = False
@@ -49,27 +53,22 @@ class EssChopper(Moveable):
         return [self._attached_speed.read(maxage),
                 self._attached_phase.read(maxage)]
 
-    def doStart(self, pos):
-        if hasattr(self, '_attached_state') and \
-           self._attached_state.read() == 'init':
-            self.initialize()
-
-        self._attached_speed.move(pos[0])
-        self._attached_phase.move(pos[1])
-        # self._attached_command.move('start')
+    def doStart(self, value):
+        self._attached_speed.move(value[0])
+        self._attached_phase.move(value[1])
 
     def doStop(self):
         self._attached_command.move('stop')
 
     def doStatus(self, maxage=0):
         # TODO: For error states set the status to not OK
+        # TODO: handle alarms as well
         return status.OK, self._attached_state.read()
-    #
-    # @usermethod
-    # def initialize(self):
-    #     self._attached_command.move('init')
-    #
-    # @usermethod
-    # def deinitialize(self):
-    #     self._attached_command.move('deinit')
 
+    @usermethod
+    def command(self, command):
+        if command in self._commands:
+            self._attached_command.move(command)
+            return
+        self.log.error('Invalid command, should be one of: '
+                       f'{", ".join(self._commands)}')

--- a/nicos_ess/devices/epics/mini_chopper.py
+++ b/nicos_ess/devices/epics/mini_chopper.py
@@ -1,0 +1,75 @@
+#  -*- coding: utf-8 -*-
+# *****************************************************************************
+# NICOS, the Networked Instrument Control System of the MLZ
+# Copyright (c) 2009-2021 by the NICOS contributors (see AUTHORS)
+#
+# This program is free software; you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software
+# Foundation; either version 2 of the License, or (at your option) any later
+# version.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc.,
+# 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#
+# Module authors:
+#   Michael Wedel <michael.wedel@esss.se>
+#   Nikhil Biyani <nikhil.biyani@psi.ch>
+#   Michael Hart <michael.hart@stfc.ac.uk>
+#
+# *****************************************************************************
+
+from nicos.core import Attach, Moveable, Override, status, \
+    tupleof, usermethod, Readable
+from nicos.devices.epics import EpicsMoveable, EpicsReadable
+
+
+class EssChopper(Moveable):
+    attached_devices = {
+        'speed': Attach('Speed of the chopper disc.', Moveable),
+        'phase': Attach('Phase of the chopper disc', Moveable),
+        'state': Attach('Current state of the chopper', Readable),
+        # 'command': Attach('Command PV of the chopper', EpicsMoveable)
+    }
+
+    parameter_overrides = {
+        'fmtstr': Override(default='Speed=%.2f Delay=%.2f'),
+        'unit': Override(mandatory=False),
+    }
+
+    hardware_access = False
+    valuetype = tupleof(float, float)
+
+    def doRead(self, maxage=0):
+        return [self._attached_speed.read(maxage),
+                self._attached_phase.read(maxage)]
+
+    def doStart(self, pos):
+        if hasattr(self, '_attached_state') and \
+           self._attached_state.read() == 'init':
+            self.initialize()
+
+        self._attached_speed.move(pos[0])
+        self._attached_phase.move(pos[1])
+        # self._attached_command.move('start')
+
+    def doStop(self):
+        self._attached_command.move('stop')
+
+    def doStatus(self, maxage=0):
+        # TODO: For error states set the status to not OK
+        return status.OK, self._attached_state.read()
+    #
+    # @usermethod
+    # def initialize(self):
+    #     self._attached_command.move('init')
+    #
+    # @usermethod
+    # def deinitialize(self):
+    #     self._attached_command.move('deinit')
+

--- a/nicos_ess/ymir/setups/choppers.py
+++ b/nicos_ess/ymir/setups/choppers.py
@@ -7,6 +7,7 @@ devices = dict(
         'nicos.devices.epics.EpicsStringReadable',
         description='The chopper status.',
         readpv='{}Chop_Stat'.format(pv_root),
+        lowlevel=True,
     ),
     mini_chopper_control=device(
         'nicos_ess.devices.epics.extensions.EpicsMappedMoveable',
@@ -15,9 +16,9 @@ devices = dict(
         writepv='{}Cmd'.format(pv_root),
         requires={'level': 'admin'},
         lowlevel=True,
-        mapping={'Start chopper': 6,
-                 'Stop chopper': 3,
-                 'Reset chopper': 1,
+        mapping={'start': 6,
+                 'stop': 3,
+                 'reset': 1,
         },
     ),
     mini_chopper_speed=device(
@@ -26,6 +27,7 @@ devices = dict(
         readpv='{}Spd_Stat'.format(pv_root),
         writepv='{}Spd_SP'.format(pv_root),
         abslimits=(0.0, 14),
+        lowlevel=True,
     ),
     mini_chopper_delay=device(
         'nicos_ess.devices.epics.pva.EpicsAnalogMoveable',
@@ -33,5 +35,14 @@ devices = dict(
         readpv='{}Chopper-Delay-SP'.format(pv_root),
         writepv='{}Chopper-Delay-SP'.format(pv_root),
         abslimits=(0.0, 71428571.0),
+        lowlevel=True,
+    ),
+    mini_chopper=device(
+        'nicos_ess.devices.epics.mini_chopper.EssChopper',
+        description='The mini-chopper',
+        speed='mini_chopper_speed',
+        phase='mini_chopper_delay',
+        state='mini_chopper_status',
+        command='mini_chopper_control',
     ),
 )

--- a/nicos_ess/ymir/setups/choppers.py
+++ b/nicos_ess/ymir/setups/choppers.py
@@ -32,8 +32,8 @@ devices = dict(
     mini_chopper_delay=device(
         'nicos_ess.devices.epics.pva.EpicsAnalogMoveable',
         description='The current delay.',
-        readpv='{}Chopper-Delay-SP'.format(pv_root),
-        writepv='{}Chopper-Delay-SP'.format(pv_root),
+        readpv='{}ChopDly-S'.format(pv_root),
+        writepv='{}ChopDly-S'.format(pv_root),
         abslimits=(0.0, 71428571.0),
         lowlevel=True,
     ),


### PR DESCRIPTION
This brings the chopper device we had previously at V20 up-to-date with the current mini-chopper.
It is a bit basic but essentially connects all the other devices into one which means they can be hidden as low-level.
I don't like that one has to supply both the speed and delay when setting it from the command line even if only one of them is changing, e.g.
```
move(mini_chopper, (14, 0))
```
Perhaps we can find a better way to do that?

On the plus side, it does make it easy to send commands
```
mini_chopper.command('start')
```
The status information is a bit basic (see the TODOs) too.

This is currently deployed to YMIR for testing.