### PR TITLE
Use the new PV name for the chopper delay

### DIFF
--- a/nicos_ess/ymir/setups/choppers.py
+++ b/nicos_ess/ymir/setups/choppers.py
@@ -30,8 +30,8 @@ devices = dict(
     mini_chopper_delay=device(
         'nicos_ess.devices.epics.pva.EpicsAnalogMoveable',
         description='The current delay.',
-        readpv='{}Chopper-Delay-SP'.format(pv_root),
-        writepv='{}Chopper-Delay-SP'.format(pv_root),
+        readpv='{}ChopDly-S'.format(pv_root),
+        writepv='{}ChopDly-S'.format(pv_root),
         abslimits=(0.0, 71428571.0),
     ),
 )


### PR DESCRIPTION
Name changed to match ICS naming convention