### PR TITLE
Adding unit to NTP_DIFF in ymir setup

### DIFF
--- a/nicos_ess/ymir/setups/event_receiver.py
+++ b/nicos_ess/ymir/setups/event_receiver.py
@@ -14,5 +14,6 @@ devices = dict(
     NTP_DIFF=device(
         'nicos_ess.devices.epics.pva.EpicsReadable',
         readpv='FS:timeDiffnsNTPEVR:01'.format(pv_root),
+        unit='ns',
         description='The difference between the Utgård EVR and the NTP client'),
 )


### PR DESCRIPTION
Adding nanoseconds.
Tested in simulated case. 
Should be tested in YMIR as well once motion stage tests are completed.